### PR TITLE
update amplitude 4.0.1

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Amplitude-iOS (3.14.1)
+  - Amplitude-iOS (4.0.1)
   - Analytics (3.6.0)
   - Expecta (1.0.5)
-  - Segment-Amplitude (1.4.2):
-    - Amplitude-iOS (~> 3.14)
+  - Segment-Amplitude (1.4.3):
+    - Amplitude-iOS (~> 4.0)
     - Analytics (~> 3.6)
   - Specta (1.0.6)
 
@@ -17,10 +17,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Amplitude-iOS: 4a3c8807b2ea5369dc11e87e23825bff01e5a922
+  Amplitude-iOS: e511a77d2c05f3cc623a40e4323e65d12ef1c322
   Analytics: 15be3e651d22cc811f44df65698538236676437b
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  Segment-Amplitude: 1c62337092c140990a619fbcea5f4765ae0b8456
+  Segment-Amplitude: ba21fa153cca4dd8338ddd72d84f506d5109809f
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
 PODFILE CHECKSUM: 15887ab73967a9c540797944e987a5ee9cc0d7e8

--- a/Example/Pods/Amplitude-iOS/Amplitude/AMPConstants.m
+++ b/Example/Pods/Amplitude-iOS/Amplitude/AMPConstants.m
@@ -4,7 +4,7 @@
 #import "AMPConstants.h"
 
 NSString *const kAMPLibrary = @"amplitude-ios";
-NSString *const kAMPVersion = @"3.14.1";
+NSString *const kAMPVersion = @"4.0.1";
 NSString *const kAMPEventLogDomain = @"api.amplitude.com";
 NSString *const kAMPEventLogUrl = @"https://api.amplitude.com/";
 NSString *const kAMPDefaultInstance = @"$default_instance";

--- a/Example/Pods/Amplitude-iOS/Amplitude/AMPURLSession.h
+++ b/Example/Pods/Amplitude-iOS/Amplitude/AMPURLSession.h
@@ -1,0 +1,19 @@
+#if AMPLITUDE_SSL_PINNING
+//
+//  AMPURLSession.h
+//  Amplitude
+//
+//  Created by Daniel Jih on 9/14/17.
+//  Copyright (c) 2017 Amplitude. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ISPPinnedNSURLSessionDelegate.h"
+
+@interface AMPURLSession : ISPPinnedNSURLSessionDelegate <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
+
++ (AMPURLSession *)sharedSession;
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
+
+@end
+#endif

--- a/Example/Pods/Amplitude-iOS/Amplitude/AMPURLSession.m
+++ b/Example/Pods/Amplitude-iOS/Amplitude/AMPURLSession.m
@@ -1,0 +1,87 @@
+#if AMPLITUDE_SSL_PINNING
+//
+//  AMPURLSession.m
+//  Amplitude
+//
+//  Created by Daniel Jih on 9/14/17.
+//  Copyright (c) 2017 Amplitude. All rights reserved.
+//
+
+#import "AMPURLSession.h"
+#import "AMPARCMacros.h"
+#import "AMPConstants.h"
+#import "ISPCertificatePinning.h"
+#import "ISPPinnedNSURLSessionDelegate.h"
+
+@interface AMPURLSession ()
+
+@end
+
+@implementation AMPURLSession {
+    NSURLSession *_sharedSession;
+}
+
++ (AMPURLSession *)sharedSession {
+    static AMPURLSession *_instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _instance = [[AMPURLSession alloc] init];
+    });
+    return _instance;
+}
+
+- (id)init
+{
+    if ((self = [super init])) {
+        [AMPURLSession pinSSLCertificate:@[@"ComodoRsaCA", @"ComodoRsaDomainValidationCA"]];
+        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        _sharedSession = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:nil];
+    }
+    return self;
+}
+
++ (void)pinSSLCertificate:(NSArray *)certFilenames
+{
+    // We pin the anchor/CA certificates
+    NSMutableArray *certs = [NSMutableArray array];
+    for (NSString *certFilename in certFilenames) {
+        NSString *certPath =  [[NSBundle bundleForClass:[self class]] pathForResource:certFilename ofType:@"der"];
+        NSData *certData = SAFE_ARC_AUTORELEASE([[NSData alloc] initWithContentsOfFile:certPath]);
+        if (certData == nil) {
+            NSLog(@"Failed to load a certificate");
+            return;
+        }
+        [certs addObject:certData];
+    }
+
+    NSMutableDictionary *pins = [[NSMutableDictionary alloc] init];
+    [pins setObject:certs forKey:kAMPEventLogDomain];
+
+    if (pins == nil) {
+        NSLog(@"Failed to pin a certificate");
+        return;
+    }
+
+    // Save the SSL pins so that our connection delegates automatically use them
+    if ([ISPCertificatePinning setupSSLPinsUsingDictionnary:pins] != YES) {
+        NSLog(@"Failed to pin the certificates");
+        SAFE_ARC_RELEASE(pins);
+        return;
+    }
+    SAFE_ARC_RELEASE(pins);
+}
+
+- (void)dealloc
+{
+    [_sharedSession finishTasksAndInvalidate];
+    SAFE_ARC_RELEASE(_sharedSession);
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
+                            completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    return [_sharedSession dataTaskWithRequest:request completionHandler:completionHandler];
+}
+
+@end
+#endif

--- a/Example/Pods/Amplitude-iOS/README.md
+++ b/Example/Pods/Amplitude-iOS/README.md
@@ -1,433 +1,56 @@
 Amplitude iOS SDK
 ====================
-An iOS SDK for tracking events and revenue to [Amplitude](http://www.amplitude.com).
 
+An iOS SDK for tracking events and revenue to [Amplitude](https://www.amplitude.com).
+
+# Setup #
+Please see our [installation guide](https://amplitude.zendesk.com/hc/en-us/articles/115002278527-iOS-SDK-Installation) for instructions on installing and using our iOS SDK.
+
+# Latest Version #
+[4.0.1 - Released on September 18, 2017](https://github.com/amplitude/Amplitude-iOS/releases/latest)
 [![Circle CI](https://circleci.com/gh/amplitude/Amplitude-iOS.svg?style=shield&circle-token=e1b2a7d2cd6dd64ac3643bc8cb2117c0ed5cbb75)](https://circleci.com/gh/amplitude/Amplitude-iOS/tree/master)
 [![CocoaPods](https://img.shields.io/cocoapods/v/Amplitude-iOS.svg?style=flat)](http://cocoadocs.org/docsets/Amplitude-iOS/)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-A [demo application](https://github.com/amplitude/iOS-Demo) is available to show a simple integration.
+# iOS SDK Reference #
+See our [iOS SDK Reference](https://amplitude.zendesk.com/hc/en-us/articles/115003970027-iOS-SDK-Reference) for a list and description of all available SDK methods.
 
-A [demo application](https://github.com/amplitude/iOS-Extension-Demo) is available to show a simple integration in iOS extensions.
+# Demo Applications #
+* A [demo application](https://github.com/amplitude/iOS-Demo) showing the integration of our SDK using Cocoapods.
+* A [demo application](https://github.com/amplitude/iOS-Demo-Carthage) showing the integration of our SDK using Carthage.
+* A [demo application](https://github.com/amplitude/Segment-iOS-Demo) showing the integration of our SDK via [Segment's](https://segment.com/) iOS SDK.
+* A [demo application](https://github.com/amplitude/iOS-Extension-Demo) showing an integration in an iOS extension.
+* A [demo application](https://github.com/amplitude/GTM-iOS-Demo) demonstrating a potential integration with Google Tag Manager.
 
-See our [SDK documentation](https://rawgit.com/amplitude/Amplitude-iOS/v3.14.1/documentation/html/index.html) for a description of all available SDK methods and classes.
+# Changelog #
+Click [here](https://github.com/amplitude/Amplitude-iOS/blob/master/CHANGELOG.md) to view the iOS SDK Changelog.
 
-Our iOS SDK also supports tvOS. See [below](https://github.com/amplitude/Amplitude-iOS#tvos) for more information.
+# Questions? #
+If you have questions about using or installing our iOS SDK, you can send an email to [Amplitude Support](mailto:platform@amplitude.com).
 
-# Setup #
-1. If you haven't already, go to https://amplitude.com and register for an account. You will receive an API Key.
+# License #
+```text
+Amplitude
 
-2. [Download the source code](https://github.com/amplitude/Amplitude-iOS/archive/master.zip) and extract the zip file.
+The MIT License (MIT)
 
-    Alternatively, you can pull directly from GitHub. If you use CocoaPods, add the following line to your Podfile: `pod 'Amplitude-iOS', '~> 3.14.1'`. If you are using CocoaPods, you may skip steps 3 and 4.
+Copyright (c) 2014 Amplitude
 
-    You also have the option to install using Carthage. If you are using Carthage, add the following line to your Cartfile: `github "amplitude/Amplitude-iOS"`. Just add `#import <Amplitude/Amplitude.h>` to import all of the Amplitude header files.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-3. Copy the `Amplitude` sub-folder into the source of your project in Xcode. Check "Copy items into destination group's folder (if needed)".
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-4. Amplitude's iOS SDK requires the SQLite library, which is included in iOS but requires an additional build flag to enable. In your project's `Build Settings` and your Target's `Build Settings`, under `Linking` -> `Other Linker Flags`, add the flag `-lsqlite3.0`.
-
-5. In every file that uses analytics, import Amplitude.h at the top:
-    ``` objective-c
-    #import "Amplitude.h"
-    ```
-
-6. In the application:didFinishLaunchingWithOptions: method of your YourAppNameAppDelegate.m file, initialize the SDK:
-    ``` objective-c
-    [[Amplitude instance] initializeApiKey:@"YOUR_API_KEY_HERE"];
-    ```
-
-7. To track an event anywhere in the app, call:
-    ``` objective-c
-    [[Amplitude instance] logEvent:@"EVENT_IDENTIFIER_HERE"];
-    ```
-
-8. Events are saved locally. Uploads are batched to occur every 30 events and every 30 seconds, as well as on app close. After calling logEvent in your app, you will immediately see data appear on the Amplitude Website.
-
-# Tracking Events #
-
-It's important to think about what types of events you care about as a developer. You should aim to track between 20 and 200 types of events on your site. Common event types are actions the user initiates (such as pressing a button) and events you want the user to complete (such as filling out a form, completing a level, or making a payment).
-
-Here are some resources to help you with your instrumentation planning:
-  * [Event Tracking Quick Start Guide](https://amplitude.zendesk.com/hc/en-us/articles/207108137).
-  * [Event Taxonomy and Best Practices](https://amplitude.zendesk.com/hc/en-us/articles/211988918).
-
-Having large amounts of distinct event types, event properties and user properties, however, can make visualizing and searching of the data very confusing. By default we only show the first:
-  * 1000 distinct event types
-  * 2000 distinct event properties
-  * 1000 distinct user properties
-
-Anything past the above thresholds will not be visualized. **Note that the raw data is not impacted by this in any way, meaning you can still see the values in the raw data, but they will not be visualized on the platform.**
-
-A single call to `logEvent` should not have more than 1000 event properties. Likewise a single call to `setUserProperties` should not have more than 1000 user properties. If the 1000 item limit is exceeded then the properties will be dropped and a warning will be logged. We have put in very conservative estimates for the event and property caps which we don’t expect to be exceeded in any practical use case. If you feel that your use case will go above those limits please reach out to support@amplitude.com.
-
-# Tracking Sessions #
-
-A session is a period of time that a user has the app in the foreground. Sessions within 5 minutes of each other are merged into a single session. In the iOS SDK, sessions are tracked automatically. When the SDK is initialized, it determines whether the app is launched into the foreground or background and starts a new session if launched in the foreground. A new session is created when the app comes back into the foreground after being out of the foreground for 5 minutes or more. If the app is in the background and an event is logged, then a new session is created if more than 5 minutes has passed since the app entered the background or when the last event was logged (whichever occured last). Otherwise the background event logged will be part of the current session.
-
-You can adjust the time window for which sessions are extended by changing the variable minTimeBetweenSessionsMillis:
-``` objective-c
-[Amplitude instance].minTimeBetweenSessionsMillis = 30 * 60 * 1000; // 30 minutes
-[[Amplitude instance] initializeApiKey:@"YOUR_API_KEY_HERE"];
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ```
-
-By default start and end session events are no longer sent. To renable add this line before initializing the SDK:
-``` objective-c
-[[Amplitude instance] setTrackingSessionEvents:YES];
-[[Amplitude instance] initializeApiKey:@"YOUR_API_KEY_HERE"];
-```
-
-You can also log events as out of session. Out of session events have a session_id of -1 and are not considered part of the current session, meaning they do not extend the current session. This might be useful for example if you are logging events triggered by push notifications. You can log events as out of session by setting input parameter outOfSession to true when calling logEvent.
-
-``` objective-c
-[[Amplitude instance] logEvent:@"EVENT_IDENTIFIER_HERE" withEventProperties:nil outOfSession:true];
-```
-
-You can also log identify events as out of session by setting input parameter `outOfSession` to `YES` when calling identify:
-
-``` objective-c
-AMPIdentify *identify = [[AMPIdentify identify] set:@"key" value:@"value"];
-[[Amplitude instance] identify:identify outOfSession:YES];
-```
-
-### Getting the Session Id ###
-
-You can use the helper method `getSessionId` to get the value of the current sessionId:
-``` objective-c
-long long sessionId = [[Amplitude instance] getSessionId];
-```
-
-# Setting Custom User IDs #
-
-If your app has its own login system that you want to track users with, you can call `setUserId:` at any time:
-
-``` objective-c
-[[Amplitude instance] setUserId:@"USER_ID_HERE"];
-```
-
-You can also add the user ID as an argument to the `initializeApiKey:` call:
-
-``` objective-c
-[[Amplitude instance] initializeApiKey:@"YOUR_API_KEY_HERE" userId:@"USER_ID_HERE"];
-```
-
-### Logging Out and Anonymous Users ###
-If a user logs out, or you want to log the events under an anonymous user, you need to do 2 things: 1) set the userId to `nil` 2) regenerate a new deviceId. After doing that, events coming from the current user/device will appear as a brand new user in Amplitude dashboards. Note: if you choose to do this, you won't be able to see that the 2 users were using the same device.
-
-``` objective-c
-[[Amplitude instance] setUserId:nil];  // not string nil
-[[Amplitude instance] regenerateDeviceId];
-```
-
-
-# Setting Event Properties #
-
-You can attach additional data to any event by passing a NSDictionary object as the second argument to logEvent:withEventProperties:
-
-``` objective-c
-NSMutableDictionary *eventProperties = [NSMutableDictionary dictionary];
-[eventProperties setValue:@"VALUE_GOES_HERE" forKey:@"KEY_GOES_HERE"];
-[[Amplitude instance] logEvent:@"Compute Hash" withEventProperties:eventProperties];
-```
-
-Note: the keys should be of type NSString, and the values should be of type NSString, NSNumber, NSArray, NSDictionary, or NSNull. You will see a warning if you try to use an unsupported type.
-
-# User Properties and User Property Operations #
-
-The SDK supports the operations set, setOnce, unset, and add on individual user properties. The operations are declared via a provided `AMPIdentify` interface. Multiple operations can be chained together in a single `AMPIdentify` object. The `AMPIdentify` object is then passed to the Amplitude client to send to the server. The results of the operations will be visible immediately in the dashboard, and take effect for events logged after. Note, each
-operation on the `AMPIdentify` object returns the same instance, allowing you to chain multiple operations together.
-
-To use the `AMPIdentify` interface, you will first need to include the header:
-``` objective-c
-#import "AMPIdentify.h"
-```
-
-1. `set`: this sets the value of a user property.
-
-    ``` objective-c
-    AMPIdentify *identify = [[[AMPIdentify identify] set:@"gender" value:@"female"] set:@"age" value:[NSNumber numberForInt:20]];
-    [[Amplitude instance] identify:identify];
-    ```
-
-2. `setOnce`: this sets the value of a user property only once. Subsequent `setOnce` operations on that user property will be ignored. In the following example, `sign_up_date` will be set once to `08/24/2015`, and the following setOnce to `09/14/2015` will be ignored:
-
-    ``` objective-c
-    AMPIdentify *identify1 = [[AMPIdentify identify] setOnce:@"sign_up_date" value:@"09/06/2015"];
-    [[Amplitude instance] identify:identify1];
-
-    AMPIdentify *identify2 = [[AMPIdentify identify] setOnce:@"sign_up_date" value:@"10/06/2015"];
-    [[Amplitude instance] identify:identify2];
-    ```
-
-3. `unset`: this will unset and remove a user property.
-
-    ``` objective-c
-    AMPIdentify *identify = [[[AMPIdentify identify] unset:@"gender"] unset:@"age"];
-    [[Amplitude instance] identify:identify];
-    ```
-
-4. `add`: this will increment a user property by some numerical value. If the user property does not have a value set yet, it will be initialized to 0 before being incremented.
-
-    ``` objective-c
-    AMPIdentify *identify = [[[AMPIdentify identify] add:@"karma" value:[NSNumber numberWithFloat:0.123]] add:@"friends" value:[NSNumber numberWithInt:1]];
-    [[Amplitude instance] identify:identify];
-    ```
-
-5. `append`: this will append a value or values to a user property. If the user property does not have a value set yet, it will be initialized to an empty list before the new values are appended. If the user property has an existing value and it is not a list, it will be converted into a list with the new value appended.
-
-    ``` objective-c
-    NSMutableArray *array = [NSMutableArray array];
-    [array addObject:@"some_string"];
-    [array addObject:[NSNumber numberWithInt:56]];
-    AMPIdentify *identify = [[[AMPIdentify identify] append:@"ab-tests" value:@"new-user-test"] append:@"some_list" value:array];
-    [[Amplitude instance] identify:identify];
-    ```
-
-6. `prepend`: this will prepend a value or values to a user property. Prepend means inserting the value(s) at the front of a given list. If the user property does not have a value set yet, it will be initialized to an empty list before the new values are prepended. If the user property has an existing value and it is not a list, it will be converted into a list with the new value prepended.
-
-    ``` objective-c
-    NSMutableArray *array = [NSMutableArray array];
-    [array addObject:@"some_string"];
-    [array addObject:[NSNumber numberWithInt:56]];
-    AMPIdentify *identify = [[[AMPIdentify identify] append:@"ab-tests" value:@"new-user-test"] prepend:@"some_list" value:array];
-    [[Amplitude instance] identify:identify];
-    ```
-
-Note: if a user property is used in multiple operations on the same `Identify` object, only the first operation will be saved, and the rest will be ignored. In this example, only the set operation will be saved, and the add and unset will be ignored:
-
-``` objective-c
-AMPIdentify *identify = [[[[AMPIdentify identify] set:@"karma" value:[NSNumber numberWithInt:10]] add:@"friends" value:[NSNumber numberWithInt:1]] unset:@"karma"];
-    [[Amplitude instance] identify:identify];
-```
-
-### Arrays in User Properties ###
-
-The SDK supports arrays in user properties. Any of the user property operations above (with the exception of `add`) can accept an NSArray or an NSMutableArray. You can directly `set` arrays, or use `append` to generate an array.
-
-``` objective-c
-NSMutableArray *colors = [NSMutableArray array];
-[colors addObject:@"rose"];
-[colors addObject:@"gold"];
-NSMutableArray *numbers = [NSMutableArray array];
-[numbers addObject:[NSNumber numberWithInt:4]];
-[numbers addObject:[NSNumber numberWithInt:5]];
-AMPIdentify *identify = [[[[AMPIdentify identify] set:@"colors" value:colors] append:@"ab-tests" value:@"campaign_a"] append:@"existing_list" value:numbers];
-[[Amplitude instance] identify:identify];
-```
-
-### Setting Multiple Properties with `setUserProperties` ###
-
-You may use `setUserProperties` shorthand to set multiple user properties at once. This method is simply a wrapper around `AMPIdentify set` and `identify`.
-
-``` objective-c
-NSMutableDictionary *userProperties = [NSMutableDictionary dictionary];
-[userProperties setValue:@"VALUE_GOES_HERE" forKey:@"KEY_GOES_HERE"];
-[userProperties setValue:@"OTHER_VALUE_GOES_HERE" forKey:@"OTHER_KEY_GOES_HERE"];
-[[Amplitude instance] setUserProperties:userProperties];
-```
-
-### Clearing User Properties with `clearUserProperties` ###
-
-You may use `clearUserProperties` to clear all user properties at once. Note: the result is irreversible!
-
-``` objective-c
-[[Amplitude instance] clearUserProperties];
-```
-
-# Allowing Users to Opt Out
-
-To stop all event and session logging for a user, call setOptOut:
-
-``` objective-c
-[[Amplitude instance] setOptOut:YES];
-```
-
-Logging can be restarted by calling setOptOut again with enabled set to NO.
-No events will be logged during any period opt out is enabled, even after opt
-out is disabled.
-
-# Tracking Revenue #
-
-The preferred method of tracking revenue for a user now is to use `logRevenueV2` in conjunction with the provided `AMPRevenue` interface. `AMPRevenue` instances will store each revenue transaction and allow you to define several special revenue properties (such as revenueType, productIdentifier, etc) that are used in Amplitude dashboard's Revenue tab. You can now also add event properties to the revenue event, via the eventProperties field. These `AMPRevenue` instance objects are then passed into `logRevenueV2` to send as revenue events to Amplitude servers. This allows us to automatically display data relevant to revenue on the Amplitude website, including average revenue per daily active user (ARPDAU), 1, 7, 14, 30, 60, and 90 day revenue, lifetime value (LTV) estimates, and revenue by advertising campaign cohort and daily/weekly/monthly cohorts.
-
-**Important Note**: Amplitude currently does not support currency conversion. All revenue data should be normalized to your currency of choice, before being sent to Amplitude.
-
-To use the `Revenue` interface, you will first need to import the class:
-``` objective-c
-#import "AMPRevenue.h"
-```
-
-Each time a user generates revenue, you create a `AMPRevenue` object and fill out the revenue properties:
-``` objective-c
-AMPRevenue *revenue = [[[AMPRevenue revenue] setProductIdentifier:@"productIdentifier"] setQuantity:3];
-[revenue setPrice:[NSNumber numberWithDouble:3.99]];
-[[Amplitude instance] logRevenueV2:revenue];
-```
-
-`price` is a required field. `quantity` defaults to 1 if not specified. `receipt` is required if you want to verify the revenue event. Each field has a corresponding `set` method (for example `setProductId`, `setQuantity`, etc). This table describes the different fields available:
-
-| Name               | Type         | Description                                                                                                  | default |
-|--------------------|--------------|--------------------------------------------------------------------------------------------------------------|---------|
-| productId          | NSString     | Optional: an identifier for the product (can be pulled from `SKPaymentTransaction.payment.productIdentifier`)| nil     |
-| quantity           | NSInteger    | Required: the quantity of products purchased. Defaults to 1 if not specified. Revenue = quantity * price     | 1       |
-| price              | NSNumber     | Required: the price of the products purchased (can be negative). Revenue = quantity * price                  | nil     |
-| revenueType        | NSString     | Optional: the type of revenue (ex: tax, refund, income)                                                      | nil     |
-| receipt            | NSData       | Optional: required if you want to verify the revenue event                                                   | nil     |
-| eventProperties    | NSDictionary | Optional: a NSDictionary of event properties to include in the revenue event                                 | nil     |
-
-Note: the price can be negative, which might be useful for tracking revenue lost, for example refunds or costs. Also note, you can set event properties on the revenue event just like you would with logEvent by passing in an NSDictionary of string key value pairs. These event properties, however, will only appear in the Event Segmentation tab, not in the Revenue tab.
-
-### Revenue Verification ###
-
-By default Revenue events recorded on the iOS SDK appear in Amplitude dashboards as unverified revenue events. **To enable revenue verification, copy your iTunes Connect In App Purchase Shared Secret into the manage section of your app on Amplitude. You must put a key for every single app in Amplitude where you want revenue verification.**
-
-Then after a successful purchase transaction, add the receipt data to the `Revenue` object:
-
-``` objective-c
-AMPRevenue *revenue = [[[AMPRevenue revenue] setProductIdentifier:@"productIdentifier"] setQuantity:1];
-[[revenue setPrice:[NSNumber numberWithDouble:3.99]] setReceipt:receiptData];
-[[Amplitude instance] logRevenueV2:revenue];
-```
-
-`receipt:` the receipt NSData from the app store. For details on how to obtain the receipt data, see [Apple's guide on Receipt Validation](https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW1).
-
-### Backwards compatibility ###
-
-The existing `logRevenue` methods still work but are deprecated. Fields such as `revenueType` will be missing from events logged with the old methods, so Revenue segmentation on those events will be limited in Amplitude dashboards.
-
-# Tracking Events to Multiple Amplitude Apps #
-
-The Amplitude iOS SDK supports logging events to multiple Amplitude apps (multiple API keys). If you want to log events to multiple Amplitude apps, you need to use separate instances for each Amplitude app. Each new instance created will have its own apiKey, userId, deviceId, and settings.
-
-You will need to assign a name to each Amplitude app / instance, and use that name consistently when fetching that instance to call functions. **IMPORTANT: Once you have chosen a name for that instance you cannot change it.** Every instance's data and settings are tied to its name, and you will need to continue using that instance name for all future versions of your app to maintain data continuity, so chose your instance names carefully. Note these names do not need to correspond to the names of your apps in the Amplitude dashboards, but they need to remain consistent throughout your code. You also need to be sure that each instance is initialized with the correct apiKey.
-
-Instance names must be nonnil and nonempty strings. The names are case-insensitive. You can fetch each instance by name by calling `[Amplitude instanceWithName:@"INSTANCE_NAME"]`.
-
-As mentioned before, each new instance created will have its own apiKey, userId, deviceId, and settings. **You will have to reconfigure all the settings for each instance.** For example if you want to track session events you would have to call `setTrackingSessionEvents:YES` on each instance. This does give you the freedom to have different settings for each instance.
-
-### Backwards Compatibility - Upgrading from a Single Amplitude App to Multiple Apps ###
-
-If you were tracking users with a single app before v3.6.0, you might be wondering what will happen to existing data, existing settings, and returning users (users who already have a deviceId and/or userId). All of the historical data and settings are maintained on the `default` instance, which is fetched without an instance name: `[Amplitude instance]`. This is the way you are used to interacting with the Amplitude SDK, which means all of your existing tracking code should work as before.
-
-### Example of how to Set Up and Log Events to Two Separate Apps ###
-
-``` objective-c
-[[Amplitude instance] initializeApiKey:@"12345"]; // existing app, existing settings, and existing API key
-[[Amplitude instanceWithName:@"new_app"] initializeApiKey:@"67890"]; // new app, new API key
-
-[[Amplitude instanceWithName:@"new_app"] setUserId:@"joe@gmail.com"]; // need to reconfigure new app
-[[Amplitude instanceWithName:@"new_app"] logEvent:@"Clicked"];
-
-AMPIdentify *identify = [[AMPIdentify identify] add:@"karma" value:[NSNumber numberWithInt:1]];
-[[Amplitude instance] identify:identify];
-[[Amplitude instance] logEvent:@"Viewed Home Page"];
-```
-
-### Synchronizing Device Ids Between Apps ###
-
-As mentioned before, each new instance will have its own deviceId. If you want your apps to share the same deviceId, you can do so *after initialization* via the `getDeviceId` and `setDeviceId` methods. Here's an example of how to copy the existing deviceId to the `new_app` instance:
-``` objective-c
-NSString *deviceId = [[Amplitude instance] getDeviceId]; // existing deviceId
-[[Amplitude instanceWithName:@"new_app"] setDeviceId:deviceId]; // transferring existing deviceId to new app
-```
-
-# tvOS #
-
-This SDK will work with tvOS apps. Follow the same [setup instructions](https://github.com/amplitude/Amplitude-iOS#setup) for iOS apps.
-
-One thing to note: tvOS apps do not have persistent storage (only temporary storage), so for tvOS the SDK is configured to upload events immediately as they are logged (`eventUploadThreshold` is set to 1 by default for tvOS). It is assumed that Apple TV devices have a stable internet connection, so uploading events immediately is reasonable. If you wish to revert back to the iOS batching behavior, you can do so by changing `eventUploadThreshold` (set to 30 by default for iOS):
-``` objective-c
-[[Amplitude instance] setEventUploadThreshold:30];
-```
-
-# Swift #
-
-This SDK will work with Swift. If you are copying the source files or using CocoaPods without the `use_frameworks!` directive, you should create a bridging header as documented [here](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html) and add the following line to your bridging header:
-
-``` objective-c
-#import "Amplitude.h"
-```
-
-If you have `use_frameworks!` set, you should not use a bridging header and instead use the following line in your swift files:
-
-``` swift
-import Amplitude_iOS
-```
-
-In either case, you can call Amplitude methods with `Amplitude.instance().method(...)`
-
-# Advanced #
-This SDK automatically grabs useful data from the phone, including app version, phone model, operating system version, and carrier information.
-
-### Setting Groups ###
-
-Amplitude supports assigning users to groups, and performing queries such as Count by Distinct on those groups. An example would be if you want to group your users based on what organization they are in by using an orgId. You can designate Joe to be in orgId 10, while Sue is in orgId 15. When performing an event segmentation query, you can then select Count by Distinct orgIds to query the number of different orgIds that have performed a specific event. As long as at least one member of that group has performed the specific event, that group will be included in the count. See our help article on [Count By Distinct](https://amplitude.zendesk.com/hc/en-us/articles/218824237) for more information.
-
-When setting groups you need to define a `groupType` and `groupName`(s). In the above example, 'orgId' is a `groupType`, and the value 10 or 15 is the `groupName`. Another example of a `groupType` could be 'sport' with `groupNames` like 'tennis', 'baseball', etc.
-
-You can use `setGroup` to designate which groups a user belongs to. Note: this will also set the `groupType`: `groupName` as a user property. **This will overwrite any existing groupName value set for that user's groupType, as well as the corresponding user property value.** `groupType` is a string, and `groupName` can be either a string or an array of strings to indicate a user being in multiple groups (for example Joe is in orgId 10 and 16, so the `groupName` would be [10, 16]).
-
-You can also call `setGroup` multiple times with different groupTypes to track multiple types of groups. **You are allowed to track up to 5 different groupTypes per app.** For example Sue is in orgId: 15, and she also plays sport: soccer. Now when querying, you can Count by Distinct on both orgId and sport (although as separate queries). Any additional groupTypes after the limit will be ignored from the Count By Distinct query UI, although they will still be saved as user properties.
-
-```objective-c
-[[Amplitude instance] setGroup:@"orgId" groupName:[NSNumber numberWithInt:15]];
-[[Amplitude instance] setGroup:@"sport" groupName:[NSArray arrayWithObjects: @"tennis", @"soccer", nil];
-```
-
-You can also use `logEvent` withGroups: to set event-level groups, meaning the group designation only applies for the specific event being logged and does not persist on the user (unless you explicitly set it with `setGroup`). The group input is a dictionary of groupType: groupName pairs, where groupTypes are strings and groupName can either be strings or array of strings.
-
-```objective-c
-NSDictionary *eventProperties = [NSDictionary dictionaryWithObjectsAndKeys: @"value", @"key", nil];
-NSDictionary *groups = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:10], @"orgId", @"soccer", @"sport", nil];
-
-[[Amplitude instance] logEvent:@"initialize_game" withEventProperties:eventProperties withGroups:groups];
-```
-
-### Location Tracking ###
-If the user has granted your app location permissions, the SDK will also grab the location of the user. Amplitude will never prompt the user for location permissions itself, this must be done by your app.
-
-Amplitude only polls for a location once on startup of the app, once on each app open, and once when the permission is first granted. There is no continuous tracking of location, although you can force Amplitude to grab the latest location by calling `[[Amplitude instance] updateLocation]`. Note this does consume more resources on the user's device, so use this wisely.
-
-If you wish to disable location tracking done by the app, you can call `[[Amplitude instance] disableLocationListening]` at any point. If you want location tracking disabled on startup of the app, call disableLocationListening before you call `initializeApiKey:`. You can always reenable location tracking through Amplitude with `[[Amplitude instance] enableLocationListening]`.
-
-### Custom Device IDs ###
-Device IDs are set to the Identifier for Vendor (IDFV) if available, otherwise they are randomly generated. You can, however, choose to instead use the Advertising Identifier (IDFA) if available by calling `[[Amplitude instance] useAdvertisingIdForDeviceId]` before initializing with your API key. You can also retrieve the Device ID that Amplitude uses with `[[Amplitude instance] getDeviceId]`.
-
-If you have your own system for tracking device IDs and would like to set a custom device ID, you can do so with `[[Amplitude instance] setDeviceId:@"CUSTOM_DEVICE_ID"];` **Note: this is not recommended unless you really know what you are doing.** Make sure the device ID you set is sufficiently unique (we recommend something like a UUID - see `[AMPUtils generateUUID]` for an example on how to generate) to prevent conflicts with other devices in our system.
-
-### ARC ###
-This code will work with both ARC and non-ARC projects. Preprocessor macros are used to determine which version of the compiler is being used.
-
-### SSL pinning ###
-The SDK includes support for SSL pinning. It is enabled via a preprocessor macro.
-
-If you installed the SDK using Cocoapods, you will need to enable the preprocessor macro via your Podfile by adding this post install hook:
-```ruby
-post_install do |installer_representation|
-    installer_representation.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'AMPLITUDE_SSL_PINNING=1']
-        end
-    end
-end
-```
-
-If you installed the SDK directly from the source, you can enable SSL pinning by adding the following preprocessor macro: `AMPLITUDE_SSL_PINNING=1`
-
-### iOS Extensions ###
-The SDK allows for tracking in iOS Extensions. Follow the [Setup instructions](https://github.com/amplitude/amplitude-ios#setup). In Step 6, instead of initializing the SDK in `application:didFinishLaunchingWithOptions:`, you initialize the SDK in your extension's `viewDidLoad` method.
-
-Couple of things to note:
-
-1. The `viewDidLoad` method will get called every time your extension is opened. This means that our SDK's `initializeApiKey` method will get called every single time; however, that's okay since it will safely ignore subsequent calls after the first one. If you want you can protect the initialization with something like a dispatch_once block.
-
-2. Our definition of sessions was intended for an application use case. Depending on your expected extension use case, you might want to not enable `trackingSessionEvents`, or extend the `minTimeBetweenSessionsMillis` to be longer than 5 minutes. You should experiment with these 2 settings to get your desired session definition.
-
-3. Also, you may want to decrease `eventUploadPeriodSeconds` to something shorter than 30 seconds to upload events at shorter intervals if you don't expect users to keep your extension open that long. You can also manually call `[[Amplitude instance] uploadEvents];` to manually force an upload.
-
-Here is a simple [demo application](https://github.com/amplitude/iOS-Extension-Demo) showing how to instrument the iOS SDK in an extension.
-
-### Debug Logging ###
-By default only critical errors are logged to console. To enable debug logging, change `AMPLITUDE_DEBUG` from `0` to `1` at the top of the Objective-C file you wish to examine.
-
-Error messages are printed by default. To disable error logging, change `AMPLITUDE_LOG_ERRORS` from `1` to `0` in `Amplitude.m`.

--- a/Example/Pods/Headers/Private/Amplitude-iOS/AMPURLSession.h
+++ b/Example/Pods/Headers/Private/Amplitude-iOS/AMPURLSession.h
@@ -1,0 +1,1 @@
+../../../Amplitude-iOS/Amplitude/AMPURLSession.h

--- a/Example/Pods/Headers/Public/Amplitude-iOS/AMPURLSession.h
+++ b/Example/Pods/Headers/Public/Amplitude-iOS/AMPURLSession.h
@@ -1,0 +1,1 @@
+../../../Amplitude-iOS/Amplitude/AMPURLSession.h

--- a/Example/Pods/Local Podspecs/Segment-Amplitude.podspec.json
+++ b/Example/Pods/Local Podspecs/Segment-Amplitude.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Segment-Amplitude",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "summary": "Amplitude Integration for Segment's analytics-ios library.",
   "description": "Analytics for iOS provides a single API that lets you\nintegrate with over 100s of tools.\n\nThis is the Amplitude integration for the iOS library.",
   "homepage": "http://segment.com/",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/segment-integrations/analytics-ios-integration-amplitude.git",
-    "tag": "1.4.2"
+    "tag": "1.4.3"
   },
   "social_media_url": "https://twitter.com/segment",
   "platforms": {
@@ -25,7 +25,7 @@
       "~> 3.6"
     ],
     "Amplitude-iOS": [
-      "~> 3.14"
+      "~> 4.0"
     ]
   }
 }

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Amplitude-iOS (3.14.1)
+  - Amplitude-iOS (4.0.1)
   - Analytics (3.6.0)
   - Expecta (1.0.5)
-  - Segment-Amplitude (1.4.2):
-    - Amplitude-iOS (~> 3.14)
+  - Segment-Amplitude (1.4.3):
+    - Amplitude-iOS (~> 4.0)
     - Analytics (~> 3.6)
   - Specta (1.0.6)
 
@@ -17,10 +17,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Amplitude-iOS: 4a3c8807b2ea5369dc11e87e23825bff01e5a922
+  Amplitude-iOS: e511a77d2c05f3cc623a40e4323e65d12ef1c322
   Analytics: 15be3e651d22cc811f44df65698538236676437b
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  Segment-Amplitude: 1c62337092c140990a619fbcea5f4765ae0b8456
+  Segment-Amplitude: ba21fa153cca4dd8338ddd72d84f506d5109809f
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
 PODFILE CHECKSUM: 15887ab73967a9c540797944e987a5ee9cc0d7e8

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,202 +7,204 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0151A7ACCBD8575A076DB6E3B9C0556E /* AMPLocationManagerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D64E3CB905590A5320E158F852FE05DB /* AMPLocationManagerDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		01E1FE82103F4DF41166848AD539EAE3 /* SEGAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C4C4D307678E2EB15890867D6B13A15 /* SEGAnalytics.m */; };
+		01E1FE82103F4DF41166848AD539EAE3 /* SEGAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = B07DCAFE90418B6612216ACFA3E804EA /* SEGAnalytics.m */; };
 		02A7244EAD1ED74B5B3394D40AA25F4C /* SEGAmplitudeIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BB8510DA94A130308CA4B3551552CBE /* SEGAmplitudeIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0435080233FFD861A266AB43BE3279D3 /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = A265ABE8989F2FFF05C1A0CFC8D71945 /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		045E77138594FCD0492D74EE7C22AC90 /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D8E7A6E4840BA29E0A4149F853864C1 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		0876CA00867AB99301D67095C964DC14 /* ISPCertificatePinning.h in Headers */ = {isa = PBXBuildFile; fileRef = 30ECA58326290498D458ABD7E37FF021 /* ISPCertificatePinning.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		098F341844A511760F91AC3739129AD1 /* SEGAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = BABCB9B2DC83996225AA8ABCE5BA6F5A /* SEGAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		09A2809D2B7B67C37D284F233E5A69C8 /* SEGFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 887A060C2E187B4063B3DCBFEF4447E0 /* SEGFileStorage.m */; };
-		0ADD42608E499AE14F259296A7B31BDD /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = FBDD472A28BA7C50D992962F37ED54DF /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B3330DD885757A45805E83A69E7AFFD /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C5F5955C56ED8C3CE768F62CF97D315C /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0435080233FFD861A266AB43BE3279D3 /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = C5CDBDAFA3F4C8492411C3243EBFE7F2 /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		045E77138594FCD0492D74EE7C22AC90 /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = B75945B18D32221F79504A270FCB9E92 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0652687B02287F1C8105F8DA90E27FD4 /* AMPDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 106B4700274B0FBFE7EB79FB5A45112D /* AMPDeviceInfo.m */; };
+		098F341844A511760F91AC3739129AD1 /* SEGAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 32852763DA17CC6C9650F629D2A1A429 /* SEGAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09A2809D2B7B67C37D284F233E5A69C8 /* SEGFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB5DE36C4DD3626244B57785F82D801 /* SEGFileStorage.m */; };
+		0ADD42608E499AE14F259296A7B31BDD /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D3D581E7B5A8E932BC6576FD0D013405 /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0B3330DD885757A45805E83A69E7AFFD /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 904651D94A1EC833EB0895379DF77C54 /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0BEB12EACD1A448BA75A9038B620A498 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
-		0CD876A643FA00F42565F0B4CFE5C360 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 062F1C5B07E68407382E548A171FEF0E /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0D3DBA7B7366DB9E7B8BD5AB459F5031 /* SEGStoreKitTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 9791B1C154ABB159E483EC759C5D7A0D /* SEGStoreKitTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0D89BC56B4A2F94B5E837EA557CE3C97 /* AMPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B399ED8120CE53B322DD036276714A7E /* AMPConstants.m */; };
-		0DA1B8376BBADCBFDBCDC4629270D6B8 /* AMPDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 56D50CD8694ACABA962CEA56EB52E318 /* AMPDeviceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0CD876A643FA00F42565F0B4CFE5C360 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 4455E03C82E46FE5D20A30630A3ADD46 /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0D3DBA7B7366DB9E7B8BD5AB459F5031 /* SEGStoreKitTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AA117E301657060FAF000750A593A31 /* SEGStoreKitTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0E46A173FDB21C2E617CD6C90EB00120 /* SEGAmplitudeIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = D483CEA65379BCA1BD171736A01004E9 /* SEGAmplitudeIntegrationFactory.m */; };
 		0E8E7C035F8969CF3DC93E5490A6158B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
-		0EDCA96D2CBABE271438F3AF1480F559 /* ISPPinnedNSURLConnectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A82B9E07D3CC1758AB734ED138878DCA /* ISPPinnedNSURLConnectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0EF8942E0E33E51B55984E21C7A20136 /* AMPARCMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = EB6C84AC521E8B87CF188A2E0FB9BB8B /* AMPARCMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0FE4C580D709657792E5661E74F171D5 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ABFC2270C607240D03045B116D23D99 /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1008476AE6C51A05025B093BE2077EC0 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 074A7F72471D17B9B39B2FD5A91BC047 /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		10D05964FA34BB77FE5B9C705C77D6EE /* SEGHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 13C3D2412FF4B6BCF60D61F4C7B85E81 /* SEGHTTPClient.m */; };
-		1117E7E92DEFCDC43417987EBCCD4C8F /* Amplitude-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DDA1F4D5BFD0477D1595C6327A471002 /* Amplitude-iOS-dummy.m */; };
-		119C10C9E57E10B254B8B13A06D332F4 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = D43D1D65266064FC1F3AB45EA899A44C /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		11B98D7660EAD3B22A6F8DAFAC8E96F8 /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = F887E9650231B6D0DA2C4B5C432BB449 /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		120A345233C900C50BAD6F3950FAB8FA /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B44C497833D4F0381DD02B45274468 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		12ADCD5E7598997A3486E62E784DB241 /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = D5434306671DC296FCAB57307AF691A0 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		12CAEA62439E19E8DC4A3CF341895A06 /* AMPIdentify.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E45FD63A79F835DF60DC7B07B1BD240 /* AMPIdentify.m */; };
-		1755E06A4DC3DD23CACFF2E69B43B203 /* SEGSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = DA70104D1AE381BEE73119B3654906F3 /* SEGSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		19CD5B9DD6DCC8F9C4221A2CB5679675 /* SEGIdentifyPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 81E8E1ED0B06B95947FF1950C097937F /* SEGIdentifyPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		19CDE56AC4388C284D9A394F64E0530C /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CAC9B15CF6343964FE25817C5243620 /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1AE4ECA523A3AE42F40E0B7A3EA53BA6 /* SEGAnalyticsConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 535E6FE9F09EE7A34A7AA0B24CFA224C /* SEGAnalyticsConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1C74D210067A2D584AA672E61F246ECC /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = 42C40EB2DCFD06A0C6F301FBD3779C67 /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1D622FBC8A4262E6B398F5CCCB1D9650 /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = DADA13181873EC8F573DBD56945C88C4 /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		1D68A0FF4C838D1216C2ED226402ED86 /* NSData+SEGGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C8FCF193AEFBCCA25FFF87324CF62DE /* NSData+SEGGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1DB6971E2D83BC7B224F8DFA7370A5F1 /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 052708A7CCE881EBBE100FC5D2A9576B /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1E2343F7AE04C5D386CCD455E84F13E0 /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = E085D8F2B03CBE9CFFB0547E2C7FBDC7 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		24FF4A3B66A2F383BA14790790108406 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 029E661288F5C15F610D9EF753C0522B /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		2523657BEE249A532CDFD495AC911F39 /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 01480A7D9CBCBE893F37EEF86A8D104D /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		25CA317BFF98D4AAE6FE7A1B942E8DB0 /* SEGIntegrationsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 211C04DC2D1B25A68A8E22F74EE9A1B5 /* SEGIntegrationsManager.m */; };
-		25CCEF151E1E62346A803F975261D24A /* SEGMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A2418FDACE26FD5D9FB10B6DD6354AD /* SEGMiddleware.m */; };
-		2766B0D10AA11D18DDCB5DB24DDD2481 /* SEGTrackPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 30059F086F05B2FA99DD533F5FCD0A1E /* SEGTrackPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27FCCC5180C87DFDA33E789CB272F278 /* SEGContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2016D9062A4D08C4EFDB187517DDD55A /* SEGContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2823E1F5FD271A506BE3145FA5F95776 /* SEGPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = CD3686A66CFB372FE347714D02A6D985 /* SEGPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2840B36845C804533CCB71B5B34B3C06 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = FE6F6EF49D7D0A74E07845A3660316FE /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		28BC58EE3C7374C4C2DEF6D029011C84 /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 04D7611B749F0892496DBCA0A48ACF55 /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0FE4C580D709657792E5661E74F171D5 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = DB257F00932050CF6FA5A533F9FEDD29 /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1008476AE6C51A05025B093BE2077EC0 /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 27205BEE57D0EF3AD7ACB7ECB8AC2ACB /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10D05964FA34BB77FE5B9C705C77D6EE /* SEGHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A13A5BD9AEFB9B1BCA7787A71B5BDC0 /* SEGHTTPClient.m */; };
+		119C10C9E57E10B254B8B13A06D332F4 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = F71F84F607CE2613616DC5D0EA723E50 /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11B98D7660EAD3B22A6F8DAFAC8E96F8 /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = E66C54443AF525E30AE725EDBC4EFA3B /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		120A345233C900C50BAD6F3950FAB8FA /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 85C54A5B9CBFC10D616BB614A3809648 /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		12ADCD5E7598997A3486E62E784DB241 /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = F9CC1D859465CCE151D6630380145955 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1755E06A4DC3DD23CACFF2E69B43B203 /* SEGSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FCAE1E4DC842EFCA104FC26C666733E /* SEGSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		19CD5B9DD6DCC8F9C4221A2CB5679675 /* SEGIdentifyPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3E8E355E79BDBF6AA673C82EB1488C /* SEGIdentifyPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		19CDE56AC4388C284D9A394F64E0530C /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = A538DE0A412504C66899D007094F833D /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1AE4ECA523A3AE42F40E0B7A3EA53BA6 /* SEGAnalyticsConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = ED58F86EDCF2935AF1DA45DAC1FD3EFF /* SEGAnalyticsConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C74D210067A2D584AA672E61F246ECC /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = 62CAEACD6EDC65D6C2E189E7FFBACE3F /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1D0611791A479C096A261974E862430D /* AMPRevenue.h in Headers */ = {isa = PBXBuildFile; fileRef = ECC3EE731EA5025CC6FC25C8726DE077 /* AMPRevenue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D622FBC8A4262E6B398F5CCCB1D9650 /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = BFA016998F2899C2ADC09D5C1BF087CA /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		1D68A0FF4C838D1216C2ED226402ED86 /* NSData+SEGGZIP.h in Headers */ = {isa = PBXBuildFile; fileRef = 13482F8367E43FE70F1A3756B1E59862 /* NSData+SEGGZIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1DB6971E2D83BC7B224F8DFA7370A5F1 /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C6E99E732850A4A8F2B696A01C2235 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1E2343F7AE04C5D386CCD455E84F13E0 /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = CFC8F91A2C864DB1EEF81E8287DEAAC3 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		21C03A3D7980F279C5E9E8D0FA3F7290 /* Amplitude+SSLPinning.h in Headers */ = {isa = PBXBuildFile; fileRef = 342018E29907F78799D523D920D3EF5E /* Amplitude+SSLPinning.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		24FF4A3B66A2F383BA14790790108406 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = A00AB0401B5B51D3D6FE7C3E1C66B8BE /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2523657BEE249A532CDFD495AC911F39 /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE4DA883DD1F9251DB34826775FB995 /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		25CA317BFF98D4AAE6FE7A1B942E8DB0 /* SEGIntegrationsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC97FE030D6C6FC932A65C612CF70A9 /* SEGIntegrationsManager.m */; };
+		25CCEF151E1E62346A803F975261D24A /* SEGMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 73BB01A277F8526FE777A73707F7076A /* SEGMiddleware.m */; };
+		2766B0D10AA11D18DDCB5DB24DDD2481 /* SEGTrackPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B49E45FBA8888E6B080D272C4E2D82C /* SEGTrackPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27FCCC5180C87DFDA33E789CB272F278 /* SEGContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 530328B68CED82B0D989DB7D28979581 /* SEGContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2823E1F5FD271A506BE3145FA5F95776 /* SEGPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = C474F4E3801C28FC7870D5C5D5C53166 /* SEGPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2840B36845C804533CCB71B5B34B3C06 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F0062B708509828C55C300839C07908 /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2882F25D2EB1C0EF7F6D9DE330D2163F /* Amplitude.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C62328863DF9BD01E9270A3B882B436 /* Amplitude.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		28BC58EE3C7374C4C2DEF6D029011C84 /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = E5DFFE614FBB489DAA5FE0EBA241F657 /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		2A5617CDAE0DC5B8B8045673ECD55A40 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
-		2B5FD5B777DF9B04E97526F403D206ED /* NSData+SEGGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = BA03B2E04B17DB398ADD5C7688CDBF82 /* NSData+SEGGZIP.m */; };
-		2C944499E3BB44E17E10959A76BBAEA3 /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CAFB6BACDAF3A80C523ABAFCBF7DB3B /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		2E991C0BDB92169EF0708C841DCAFE46 /* ISPPinnedNSURLConnectionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 383D4A452F00117A26C971A8B572188A /* ISPPinnedNSURLConnectionDelegate.m */; };
-		30D66AFE4B0D8978F0B3316E0401AE27 /* SEGTrackPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 12F313B56D2FCFD91427AD8EB2C2E916 /* SEGTrackPayload.m */; };
-		31D27BF6DE823F040465EEC46431E22E /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 2569283733FA66D4BCD8B9CE107C1ED1 /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3244A42CFC37199A30954101052951A6 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 10550C05222935F9FC33D144292240FB /* SPTTestSuite.m */; };
-		3590C16CE4E209805008107AA030298F /* AMPIdentify.h in Headers */ = {isa = PBXBuildFile; fileRef = 463B99F50CCAD25F5EAA7EA8D9D72970 /* AMPIdentify.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		362AA7CA878404130847467DF54FF59B /* SEGUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B0135A3C0749A259EA98A8504132376 /* SEGUtils.m */; };
-		3817B7AF61DE470B5DE529E985D54006 /* SEGUserDefaultsStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E4D103CAE09CC3696359FC39E1DC405 /* SEGUserDefaultsStorage.m */; };
-		381CBEA09462B631CF59E080ABEBBE46 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6479793D1B08323285DCF6969FBE89 /* SPTSharedExampleGroups.m */; };
+		2B5FD5B777DF9B04E97526F403D206ED /* NSData+SEGGZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B23CB2BF8335FD971D75F9E70E11672 /* NSData+SEGGZIP.m */; };
+		2C944499E3BB44E17E10959A76BBAEA3 /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E93604C6325CF2806F5AFAF2D135214 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		2E97D89D5359566FBD438FC19E4744B0 /* Amplitude-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC292D2AD17D32A41AA8F215552057E /* Amplitude-iOS-dummy.m */; };
+		30D66AFE4B0D8978F0B3316E0401AE27 /* SEGTrackPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 12EFBD73F6A98774AB16D5F36AB1657F /* SEGTrackPayload.m */; };
+		3146D30BD7AB190A00B09B0888C2E8A2 /* ISPCertificatePinning.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BACD39777742EB692EEA6B0E2B6B8FE /* ISPCertificatePinning.m */; };
+		31D27BF6DE823F040465EEC46431E22E /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = 697A8911084F828C89B4829E1BEF6A30 /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3244A42CFC37199A30954101052951A6 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = F3FE21B9039733E71B93E512AEC4A6ED /* SPTTestSuite.m */; };
+		362AA7CA878404130847467DF54FF59B /* SEGUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = D9155026603089F4E514ADBBD5CDED30 /* SEGUtils.m */; };
+		36E9E2403F3FA060379B647B429C22B7 /* AMPARCMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D4FC7ABCD2E0489967F7ED31C490964 /* AMPARCMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		381147232BF488D76C6257F98C94D44F /* AMPLocationManagerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 439659C5E707F12F8FF8D9377D22DC12 /* AMPLocationManagerDelegate.m */; };
+		3817B7AF61DE470B5DE529E985D54006 /* SEGUserDefaultsStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 2846E10F9BF1609A4DA7F0E08EDFC2BF /* SEGUserDefaultsStorage.m */; };
+		381CBEA09462B631CF59E080ABEBBE46 /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = 114FF9105326AB0F3517997351EBCC69 /* SPTSharedExampleGroups.m */; };
 		384915A0A46B90BBC287356108396DB7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 506305E384D8649522C457A759AC24B9 /* Security.framework */; };
-		391226D83570CA724B533A2C609A5EF5 /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = FC6581939835E2791A4600EF8E2B13F7 /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		41BC179176427C07378D1D4EE7F2F017 /* SEGIntegrationsManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 92E7E223FB84E9BB010C15000FEEA0E2 /* SEGIntegrationsManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		47E018E82EA7801C93BE8D632FBAA3EC /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 90DE6A11107EDD0F3236A7191A03ACB2 /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4943F7D828D56A874ACCA7AC312F863B /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = C9AC24784C30C3431EB1F8DDBC633F96 /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4B76A75E1FA371E7EF6C821CD52514A1 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = C3F06A32ADD89B7686A0D540F7E44AF4 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4C2D57EF131B9A1AA1A65F36DA717BC7 /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = D858488EB708C48EDA7ACE8FDC3CF949 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4E89738B989CA5A6018187E52FE0E216 /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 826EB24E197AEE07B0F1A40AF42E9E24 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4EB308BF802E6F21BABDA8B8718CC7AB /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = F639DD9CA0941BB5736CD8E0EEB30952 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4FE0FA38EA4BC9922DB982A2FB4B504A /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 81D5FADF1DDB8237256230366055DE7B /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		53F578014F5FE7D6E9E50EF8832EA94D /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B352EF08411BAB450770E6E407CCEE55 /* Specta-dummy.m */; };
-		548BA1D333A17345DD263048EF8B7202 /* SEGIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 775B24803BDB4696043B72B523099331 /* SEGIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		54F0E687B183C8E034CA170379539921 /* AMPDatabaseHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 811047735893AECD2736A9A99732CB9C /* AMPDatabaseHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		57CDB8C458B23151680A72F8FF790C2A /* AMPLocationManagerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = BBBA8ED4F916BC134AC1AFF7BDEE5082 /* AMPLocationManagerDelegate.m */; };
-		57E943BB4B720435399811908E6DEF47 /* SEGSegmentIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = EA46FED4F2CB942CAE0D2962694E986A /* SEGSegmentIntegrationFactory.m */; };
-		585DD6A5DA1B7D77FC03B66CD765BF20 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 670C6376CF3221E88A973FA56828596A /* SpectaDSL.m */; };
-		58E38027B0A4F6CA7BE54F0AE8D4885B /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = D089DD0061232FD80BCC676DEF86C5DB /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		391226D83570CA724B533A2C609A5EF5 /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = F64744364C0608515F7235BD4B18B063 /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		41BC179176427C07378D1D4EE7F2F017 /* SEGIntegrationsManager.h in Headers */ = {isa = PBXBuildFile; fileRef = EF5FCF7F455CD87F6C1A598CEAD733F0 /* SEGIntegrationsManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		47E018E82EA7801C93BE8D632FBAA3EC /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 037D39CEA5DC274C66042BFEA46945FD /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4943F7D828D56A874ACCA7AC312F863B /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 07BD7C1EC40068C97F0FE12085EEE12A /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4AA93E82A0B82EFC88DFFE8542F68247 /* AMPRevenue.m in Sources */ = {isa = PBXBuildFile; fileRef = 049666E8CB9D1EBE336D9FE1B8B36DA6 /* AMPRevenue.m */; };
+		4B76A75E1FA371E7EF6C821CD52514A1 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = C78DD6ECAC16219186C8694F3636ABE4 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C2D57EF131B9A1AA1A65F36DA717BC7 /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = E82064F20937870458AAA758DA8DE996 /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C81A557F494048C6BDED0223F280986 /* Amplitude.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D922C3CFE46CE8B2BAFBC23E7BA316D /* Amplitude.m */; };
+		4E89738B989CA5A6018187E52FE0E216 /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B3B423BA8A318512E8E54ADE4314BB5 /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4EB308BF802E6F21BABDA8B8718CC7AB /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 87300EAB4B8D40E44664C39237A572A4 /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		4FE0FA38EA4BC9922DB982A2FB4B504A /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CA660ECD5289B2E9F913D6BFB187FA7 /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53F578014F5FE7D6E9E50EF8832EA94D /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B22B6EEAA9F357DCDCF57019CACE60FD /* Specta-dummy.m */; };
+		548BA1D333A17345DD263048EF8B7202 /* SEGIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = E81342EE4802355DA2D643EFC3C55FFB /* SEGIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		57E943BB4B720435399811908E6DEF47 /* SEGSegmentIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A76C9D6428C008893C71A6857516C7 /* SEGSegmentIntegrationFactory.m */; };
+		585DD6A5DA1B7D77FC03B66CD765BF20 /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F0FE2B5A0B556A439AF293EA85F7D79 /* SpectaDSL.m */; };
+		58E38027B0A4F6CA7BE54F0AE8D4885B /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 83A0B0BFEC9A20036CF5D2DA955A9416 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		5D257566DEC4A11322C3969E57CC91A0 /* Pods-Segment-Amplitude_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AD2B51B9DF1EB6EBD5C6AE262275806A /* Pods-Segment-Amplitude_Example-dummy.m */; };
-		5D40C3F5EBFBB938CFA8D75FDD7A9A88 /* AMPDatabaseHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D9C73F07D5ED825725897F344AD37D7 /* AMPDatabaseHelper.m */; };
-		5D50DA13C7A8B2AF549AA4F05E69F9F4 /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 1827C80EB52169F66AADCF22D57C0F01 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		5E7EB1364E196DE977F6F09E7A535B9D /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 426EC199E1D780EE7F9889E140D03AF3 /* SPTCallSite.m */; };
-		5EB8C17604A5FCA7B0F9174850D0441F /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 04C997D20AAE150754DC2D008D97C002 /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		61E89F8C6D2C5658ECADCC9BE04E4E0F /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A1ED211388C33C2B02FB3B847D5FEEC /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		62A200B73B76F6740A3EEA168FBFFF41 /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = D01ACB8983BBEBD8B787B3E66808DBBA /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63416ABA310F6C3F10171BECE5AF8757 /* SEGIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = AE9536CC20968448AEB856438F0FE8E5 /* SEGIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63CDCCAC82CBC33021220531D93213A2 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 23353B63CC7BA6791AD8A80B65C560F5 /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		643DE0287F1066D083368EAC928DF078 /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = B910263EE03D2C9834FFBCC0C953AB8E /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		660BEA8AC93BC6DF29A73D1570C10120 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AFBF8397123195FC2207F60E5EC35EB /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		69DCF5F3A96B49720B728BA6EF5E095A /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = B84AFD134B3A2F20C256F4CC4DCF5EDD /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D50DA13C7A8B2AF549AA4F05E69F9F4 /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = CDC505070B4250C297A5D7CF0DFCF9D7 /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5E7EB1364E196DE977F6F09E7A535B9D /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = DF8CD68C7CD09BA1BEC89141745B6966 /* SPTCallSite.m */; };
+		5EB8C17604A5FCA7B0F9174850D0441F /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 91B36DC084E95D0276C05B3696031C48 /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		61E89F8C6D2C5658ECADCC9BE04E4E0F /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = 3068851374CC58D083398FDC1F834B05 /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		62A200B73B76F6740A3EEA168FBFFF41 /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = A1CCB973F606819CC7C2A7DB16FF383B /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		63416ABA310F6C3F10171BECE5AF8757 /* SEGIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 2601D11F4D446F8940EAF29716212E6E /* SEGIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		63BF505FE1B3A51426DAE5780BF6145E /* ISPPinnedNSURLSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FE454C0929DACA9BAD6BDAF8E6523084 /* ISPPinnedNSURLSessionDelegate.m */; };
+		63CDCCAC82CBC33021220531D93213A2 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = DF189E35266595DAB93B664E6198608C /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		643DE0287F1066D083368EAC928DF078 /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 447C54C123E313B6D12066A7C9D1BE60 /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		660BEA8AC93BC6DF29A73D1570C10120 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2504FB7A69B6D51A64C2D15DFE4FDD /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66A33667769C45DF871D2B58589642C2 /* ISPPinnedNSURLSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 76C307D7FC8D3AA8ADC048D811E3676C /* ISPPinnedNSURLSessionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67E7E223BBB8307F3E9286B94E3498B8 /* ISPPinnedNSURLConnectionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = BF06C3113CD98F25E4E3B0E64788E313 /* ISPPinnedNSURLConnectionDelegate.m */; };
+		68B38793E0574CD875EDD8E1BC914262 /* AMPDatabaseHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = CD3946468521A5C03872FAED0AEB8B9A /* AMPDatabaseHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69DCF5F3A96B49720B728BA6EF5E095A /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2240B5CBAA31E45426F2615A5F65A7 /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69FB2EF49FBFAFCE219F6F36D671F042 /* SEGAmplitudeIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 294F0F58FC81E22F3FD9D25767F23C32 /* SEGAmplitudeIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6EECEC0333224B25DDD5E9D0B582A43A /* Amplitude.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D8A786B94C7E00341A80BF140AC9918 /* Amplitude.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6CFC9A323BC815AD85E9C18658A85C75 /* AMPURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 4965FF0C8B97FDC1BFCCEEB48A4009AF /* AMPURLSession.m */; };
 		6FBF87A9136D69B4A37F315E41A6629D /* SEGAmplitudeIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CF250516F4030814DF72DA39CADACD6 /* SEGAmplitudeIntegration.m */; };
-		7003B325C219486E031DE7277E9F05F5 /* SEGAnalyticsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 852F41FE0DEC18E699B7C269B3B087A2 /* SEGAnalyticsUtils.m */; };
-		7100640F169A4EC93CA15F0D8B5AFE8F /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 34981AF8FD0AA321CE63B26FF54AFBF8 /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		713C3AFDE1E5A1794750922884EA54BE /* SEGReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C14F0FB1BD4B13E096EC7F35FC74441 /* SEGReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		71FBC2F8907E29EB767026E6A08F7EEF /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBCFC6EA657BC510C43DCE96BCD865F /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		758DEBDF2FAAF498477B2474D090E998 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D6688073A8B98C99AFA0DAD52F38EA4 /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		759844DDE72F3BE03D9DE757B6869BFE /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B2F4923D3F9DBBD915235BFF34A351 /* XCTestCase+Specta.m */; };
-		76FFE0A5253E08250D976CAE912B89D9 /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BD36129947FA0AA12F7D4F8EB940E56 /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		78C8DCB7421F061F52FAC2AACD10C031 /* ISPCertificatePinning.m in Sources */ = {isa = PBXBuildFile; fileRef = 8410116518AC02B7B7FA8E1C72DFB851 /* ISPCertificatePinning.m */; };
-		7A50398D1D6F1D22165ECAA192F9D1CF /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = CA7A24A8996C22462C2EDC4F01035228 /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7C4FFAF7E7BD72B4775C2966898B3A83 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B59B4359A00BAA62A4056EF8E7A2923 /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7D983A5C98C1EEC21A55431FB99C1D7C /* SEGGroupPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = E07065758CC70FC2D885E41D8CC58125 /* SEGGroupPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		84049BDA6FBD7B182C9F042ACAD324A0 /* AMPUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FA2A3892483B8B8DE3BCD494B2CBBC5B /* AMPUtils.m */; };
-		863C5CC8F4698A0C85AB53C9B072D889 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA20B01CB3FFD49FBB770361088479A /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		87C087B7F1B93C2DD0B42A93B3E9D9C4 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = CB47AC06F9FF53943AD1E3614667E18E /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		87DB138611EC83A096106D770036181E /* SEGScreenPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = E7BF3C01FAFCDE8A77508E8955E94738 /* SEGScreenPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		885C2534832AF6B1DFA98FA19C4D9994 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = BF8FF5C73BB79B423731E0905C8AC6CB /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8994485FB1398BF225377D4C109CA38B /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = D948C2A998FA9EFDA262DB873785DBEE /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		899FEA8AB5E7DD13099D739016A7C8B0 /* AMPURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = CC08FDF6CA2199E0B1B0AE6564F70491 /* AMPURLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A259F0500794396328C60A33A5A3930 /* SEGMiddleware.h in Headers */ = {isa = PBXBuildFile; fileRef = 35CDA8795091411CBBAE195C039E8222 /* SEGMiddleware.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8E30CDE98AE76889A05C992DDB59DC2E /* SEGContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C7ECE7F16091058BFF65B4E6DF256DF /* SEGContext.m */; };
-		8F5052D2505E86B39D14B074FC350C3D /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 669471B098D52AED0FAF3BBB2F239C1F /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		91D8431BA59D228005F9ECD6A3508A81 /* SEGGroupPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 0245D4F7384198D81E95FB65F210D6D5 /* SEGGroupPayload.m */; };
-		9222A5F6FA8C2B4998317EBD8BA35F8E /* SEGCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 564D7B2B174AB666A303BC00345E11F6 /* SEGCrypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		948DCC6A829CB6D0CC2E460D7EC62AE2 /* SEGSegmentIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = EC03DAFBFF72340793C1DDE3324E5925 /* SEGSegmentIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		94C94F986312F61D076591DBCEC07104 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = E572DB4276FD57089332A893BF45EB3C /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9BB2A834CDB33DBE81DBC78223D6F581 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 42A56A8F8C726F86F98F0CE6982607D1 /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9CE3CC7052A6A955BE1A98E9145392C4 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = A80CE8B4914733F05FA29D5E6EC1A075 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9D834FA9C8E76DF8B8F339EE76B9D4AC /* SEGStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F895F4449950843D39F57D4C3A020B0 /* SEGStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7003B325C219486E031DE7277E9F05F5 /* SEGAnalyticsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC0F9D3BE9D166BC76B017F6047DDD /* SEGAnalyticsUtils.m */; };
+		7100640F169A4EC93CA15F0D8B5AFE8F /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 02FB07BABF1E9304C556734FD1D614B1 /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		713C3AFDE1E5A1794750922884EA54BE /* SEGReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = EC70FF0DBAD37273B6700C66A330F9A7 /* SEGReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71C6345D00ED8D55C5EFD3390B00E839 /* AMPIdentify.h in Headers */ = {isa = PBXBuildFile; fileRef = F1510DBB1658AD2CF375BD17B3C9DA7D /* AMPIdentify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71FBC2F8907E29EB767026E6A08F7EEF /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C311E99953DBE59C3D36FF8313E7DD6 /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		758DEBDF2FAAF498477B2474D090E998 /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 28D7F35F2E6AF80FDEB18D7EC82B4675 /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		759844DDE72F3BE03D9DE757B6869BFE /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = A72B4ED9BE22367B0C80D360DE43A738 /* XCTestCase+Specta.m */; };
+		76FFE0A5253E08250D976CAE912B89D9 /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EB8345DC7265292F389D3485E3ACDAA /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7A50398D1D6F1D22165ECAA192F9D1CF /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 6073F569662785196B3A57674CCABD27 /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7C4FFAF7E7BD72B4775C2966898B3A83 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E54D5395053660ED0C4CCD8EDBCE2CD /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7D983A5C98C1EEC21A55431FB99C1D7C /* SEGGroupPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = C0F302DA1F3BDDA8AFA387162D474668 /* SEGGroupPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8104810999ADB5B9268551391F536E97 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
+		863C5CC8F4698A0C85AB53C9B072D889 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A6F256393F6A7EFE7ED6239F9F6ED46 /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		87C087B7F1B93C2DD0B42A93B3E9D9C4 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F45ECA8987D0089E95769120E5A740 /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87DB138611EC83A096106D770036181E /* SEGScreenPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BB94DC2E803F41549F32ADDF85110E7 /* SEGScreenPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		885C2534832AF6B1DFA98FA19C4D9994 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 98673472A9C5E362EDCAC00FD68E264E /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		8994485FB1398BF225377D4C109CA38B /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = B339E4D939EF4F6434767CF492722E7A /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A259F0500794396328C60A33A5A3930 /* SEGMiddleware.h in Headers */ = {isa = PBXBuildFile; fileRef = 21CF6CA8D88D7E8BBFEB5D6317F6FA8F /* SEGMiddleware.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8E30CDE98AE76889A05C992DDB59DC2E /* SEGContext.m in Sources */ = {isa = PBXBuildFile; fileRef = A7E26ED2242DC4C7BBE47EB62E399A38 /* SEGContext.m */; };
+		8F5052D2505E86B39D14B074FC350C3D /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = D4804B196F00926BF7039E981AFF5201 /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		91D8431BA59D228005F9ECD6A3508A81 /* SEGGroupPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = BE80018AFD761E1C8BCCB18C903636EE /* SEGGroupPayload.m */; };
+		9222A5F6FA8C2B4998317EBD8BA35F8E /* SEGCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 768E730FF9F2CA87AC264B37D6D28F37 /* SEGCrypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		948DCC6A829CB6D0CC2E460D7EC62AE2 /* SEGSegmentIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = C6F585211CBDFD0BAECA45BB97D78A9D /* SEGSegmentIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94C94F986312F61D076591DBCEC07104 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = B95634D2C2A67A4044B32F32B6F35BC8 /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99C1B92360E0411FB3567C7A7B5BD093 /* AMPURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 469035B8DA115714C2F921BA21D53A60 /* AMPURLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9BB2A834CDB33DBE81DBC78223D6F581 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = B54549AE2FB2CA5C171A7570CC94E0DF /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9CE3CC7052A6A955BE1A98E9145392C4 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E9F45CA27D7D108F1A2715C25141A0 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D834FA9C8E76DF8B8F339EE76B9D4AC /* SEGStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = B93FEF6ADEF7DB5BCDE84F78927CB62F /* SEGStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9E4F01D986D47FA98899A967F4B35627 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8960D86C5295BDF7B75BBDAAE0E08F9C /* XCTest.framework */; };
-		9ED19D12A2A7057447CF7D73DD69834B /* SEGAnalyticsConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = ED63303A6EAE693A30D3206225EFC939 /* SEGAnalyticsConfiguration.m */; };
-		A03BA7209829EB54348537CF7F0A1BB0 /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CA6702B35516C5F8DB5D7827B1D3106 /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A12B39559E464A1089E4389274973616 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = C84412F83A5F148364D1E67B847D77CD /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A193FB77C3606DE847937B79BD869F26 /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CB44D917789B23A1069A81835C8D3A8 /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A5CB8C92268FCAC7B00F12EE55B43338 /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = CB68BD5E52A21270EFAAEE385E631CBA /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A8B2B16BBD253842E4441FE75FB8D144 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 319CD8F9255AB12DC3E5500AA4A7277E /* SPTExample.m */; };
-		A904D2D6242F68CC3B959E2B0FC8B4F9 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3265087784501F7BE4519246D7587E /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A968B42167A6264A8B5405DA5DEA1316 /* SEGPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = D3AF662787AD08B455F0CC8A8A8CBF74 /* SEGPayload.m */; };
-		AADE5EFE0BC051209E977C9FEA8BA869 /* SEGUserDefaultsStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 22D9B27E3593B4FE7E6F1E31FDF5BF31 /* SEGUserDefaultsStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB05672D2BBA27098774098132FDA347 /* Amplitude.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D01DE19A9AF6EEE3EE27FD208E8E204 /* Amplitude.m */; };
-		AB5B8C6900A48EE87F3ED90CFBD63451 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AFD81A519442C17BD66D4CF6869208D /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AE83B05C013BA59557BE041CA4166452 /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 733E054797F042C3899A8835485E84E9 /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AEC79BAAF76931FE195B0FE2B0758CDA /* UIViewController+SEGScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 41FD8F7ECD70A1B0DEB7A663FD6AEE37 /* UIViewController+SEGScreen.m */; };
-		AF15E3217F4C0433B8E2D0EE2D7766F4 /* AMPURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = BCC428E1754486F4215F62E74C6387F0 /* AMPURLConnection.m */; };
-		AF740EB1D5B8968C6D3B2767520A9A7E /* SEGSegmentIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F8A2CB61EA957F84C62D74D090E3A2F /* SEGSegmentIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9ED19D12A2A7057447CF7D73DD69834B /* SEGAnalyticsConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B29D3397DD8F4BD4594A0BAA6F396B7 /* SEGAnalyticsConfiguration.m */; };
+		A03BA7209829EB54348537CF7F0A1BB0 /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = FF2EE7D7AF3B77748F0B1CAB1E80A9C4 /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A12B39559E464A1089E4389274973616 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 486E670BE7029ECAE44C8FB8B3422DD6 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A193FB77C3606DE847937B79BD869F26 /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = 4476A3BC8005F9AA025A4C79112746FA /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A22D5A3CDC023E295BCD8691C3652221 /* AMPURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 94FD2853D0A0D17EBC31540ED4F0AAD9 /* AMPURLConnection.m */; };
+		A5CB8C92268FCAC7B00F12EE55B43338 /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = A6A39483C7584E1F98C518913C94CECF /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A8B2B16BBD253842E4441FE75FB8D144 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = DF91A61519ACFB2C467422128D789F5E /* SPTExample.m */; };
+		A904D2D6242F68CC3B959E2B0FC8B4F9 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B5801A720209F5877FCA6A2481DF02 /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		A968B42167A6264A8B5405DA5DEA1316 /* SEGPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C292C4386D7C4728ED9E5A1E1D2511 /* SEGPayload.m */; };
+		AADE5EFE0BC051209E977C9FEA8BA869 /* SEGUserDefaultsStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 277128513D3F88935753AABDEF48C2E6 /* SEGUserDefaultsStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB5B8C6900A48EE87F3ED90CFBD63451 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EAB98B9DEB4AB708653F15889D263A9 /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AE83B05C013BA59557BE041CA4166452 /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DA534F4A25B3D8D7DEB7FB04D7DA2EF /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AEC79BAAF76931FE195B0FE2B0758CDA /* UIViewController+SEGScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 91F2424E9BA318B7BE3666EBA199DB4E /* UIViewController+SEGScreen.m */; };
+		AF740EB1D5B8968C6D3B2767520A9A7E /* SEGSegmentIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = FC6AB127252F815D4765407629CAEE79 /* SEGSegmentIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B0BCF62DB26E02D1D46E1E15F8AB65CA /* Pods-Segment-Amplitude_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A6F093B825E61FB0E72EBADC74BEC8 /* Pods-Segment-Amplitude_Tests-dummy.m */; };
-		B1820A5E15F22942E386756A0473E808 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA96730930522599FDCF58FD5822C3C /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B182AF7707EC7B1F083434455C7013CE /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D1DD8BF06883C96A75A1C226FAFA4C0A /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B1964DABF421B8BA6BB9AB9E1CC0E387 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 973EF3AA585F3267168AF659D90CDB74 /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B1B304AF4CB201FDD64A237D0462EF06 /* SEGStoreKitTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CF93D12AF0BFAE9EC32A912522FA036 /* SEGStoreKitTracker.m */; };
-		B241CF27E6B9D2DBC3236BDC1BDA5B69 /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = D9D85E56DACBB8185EA48758696A1690 /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B2880B5D7D91AACFCEF345934CFEBA55 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 244ACD2F7A8506674928052A373C222A /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B33B8E92F71831308FAF80013149B143 /* SEGReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 391E38B40014B3C5AE2649E5BB162657 /* SEGReachability.m */; };
+		B1820A5E15F22942E386756A0473E808 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = DC9D4EFC036270EB591EF8238A462E0A /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B182AF7707EC7B1F083434455C7013CE /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE56EFE03C000589BBC46DC061FF713 /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B1964DABF421B8BA6BB9AB9E1CC0E387 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 541F0E672A7801C26E964E01B514852F /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B1B304AF4CB201FDD64A237D0462EF06 /* SEGStoreKitTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C1E9A6CE1C5CE2A2940D0C39384385B /* SEGStoreKitTracker.m */; };
+		B241CF27E6B9D2DBC3236BDC1BDA5B69 /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 6388B8E2B5D07C3F842D48F79BA6F4F3 /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2880B5D7D91AACFCEF345934CFEBA55 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = CEA82773650054498F0853656DCB9F78 /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B33B8E92F71831308FAF80013149B143 /* SEGReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = EBFAD0477BEBB7D20FBA513911C18760 /* SEGReachability.m */; };
 		B37F027FE6E7734B7E333BAEC4F292D9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
 		B64D916925D6355192B34ACBF0E3CAB0 /* Segment-Amplitude-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B571ABBAD558ACE1F43D77E97FCA9CC8 /* Segment-Amplitude-dummy.m */; };
-		B709C0890B67EB6C1AB9B9738CDBEEC6 /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BC3C426DCD8089601C1B6528A19AF8A /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B72D6F9CD6DCCF9339A269BC0CABA88C /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 23E622EC871443CB64E795D87CC3EB8F /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B7FB8C30C577D624F5E0B1FDB3E6CD8B /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = DCAA5F30C6F6543404727957A092A302 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B874982F26CB6C07AFAFC0C17226B4A7 /* UIViewController+SEGScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE4B1D248315C223B3A581F8E079024 /* UIViewController+SEGScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B993F13DD56DF77BA97FC9CF49A671EF /* SEGAnalyticsUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 7898DBA0A41336906E5CC5DD30A0CA7F /* SEGAnalyticsUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BAA98BF425D78B9F9FB405680EA0CB3D /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = C7864D2D58FF8CFBCE767B659A43CE52 /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BB0E62892680D990AC167E4629F95062 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = AC710D09972E764BC5D2F36D869DABA3 /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BEB9C4C641EAB47778F648CC63EA9B4D /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = C22B1B3B9FEBE179CC63DFB3E09852BD /* SPTSpec.m */; };
-		BF3A4835EEF6AAE04527CD6C6A682F6C /* SEGFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E3B3080AA80EBFA42AA8A004E583C0 /* SEGFileStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C091203A57422574B3263D1E9BA53A87 /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = FA88632FC097D02CD0C50B14D40A0D07 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C26783210FE587F52DF3F587BDCA3832 /* SEGAliasPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 95CDF764B3AB9BEF612C6FE52DBEBBB2 /* SEGAliasPayload.m */; };
-		C498F24E736A80A0F6C440DBC33AF494 /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 349E06C875B231081A714DC34B9E8F70 /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C64C4032827660F5ED12E425857BE673 /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 683CAC4BA6B707B65F2326EAFFB2CDCA /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C670343470EAC260E60ABD463CC39E2D /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 818103592EEE2F0699560E22A2283FA9 /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C94A4613CC9925FF2001DFDA4CF6AB7C /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = B87CB82AEE07830FD01226B42F26BEFB /* SPTExampleGroup.m */; };
-		CC14BE1A09E4F4CF70C172273E2E6493 /* SEGAES256Crypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 057CE4BDD50D52C36831D6C4432CE58E /* SEGAES256Crypto.m */; };
-		CC962164B5364136CF8E00A74D4E8D63 /* SEGIdentifyPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 42A11F8A655956BD0ECBF23D916DF693 /* SEGIdentifyPayload.m */; };
-		CC995F4F36E9D6237AFC6F729364B867 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F06571EBB8704E1E305134C325265164 /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		CDA268F5B643324DD61A0E25BD4179ED /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 68103AF3D0F9D0B3F8A870030B2B7622 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		CFADF209CAA4F83200AAA396001E227C /* Analytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F901DD6B56C5ACD0460F3D6D30DB4502 /* Analytics-dummy.m */; };
-		D0DE286578576CD7CF4549D4DEE7A55C /* SEGUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = EC4CA971AB0200877A46A94826217D3F /* SEGUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0E39CD4D1D6437064DFA0ED3A52B804 /* Amplitude+SSLPinning.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F0C6DD38DA9D5638A24CF31194BDD0C /* Amplitude+SSLPinning.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0FBACFDA11A4FBD836DADFDDB78E065 /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = F8774BD83503B7DABCBA54451223F381 /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D234263EFF5DB51E4FBA10414C8D1A70 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = D0C4D91D8EEAD9CFADD8FCD3FCEF72A0 /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D2E41B1A5DAFEC9EB7FB1AED4CDA55D1 /* AMPRevenue.m in Sources */ = {isa = PBXBuildFile; fileRef = 58A06AAF545D60E532B5E580D8575E4B /* AMPRevenue.m */; };
-		D3B4D194BECF709DFA85E588891B885E /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = 62BFD73EE1987F0FECC76F506D9891D4 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D5378B33D419C4831E260344216409B5 /* AMPDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F699F59178DA3C46F68433B6281BC57 /* AMPDeviceInfo.m */; };
-		D8A629FB9E1A3A121FB1125453452844 /* SEGScreenPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = A50B67FF1D6096FC9872483DC8E2EA0D /* SEGScreenPayload.m */; };
-		D94F3CDE976C052BF0BD112E257A7F19 /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DADC0B7BA89EEC028DDFED11BBAB9DA /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DC98C3CE439498B0039EF71B5A7C6FA0 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DA2CE5A5C54DC8DE8843ECC48238783 /* SpectaUtility.m */; };
-		DE508A430274EB059C82112D80AEE297 /* SEGAliasPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C83BEB5247FF766E2A486068177A78A /* SEGAliasPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DE50E4D62DF4F2445DC91B86E1E919DF /* ISPPinnedNSURLSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 407630499F85D93A69E7AF248DA6ED49 /* ISPPinnedNSURLSessionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DFFE7035A8177E14B29DE53973AE3B1E /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = B89E639E443D6A119B1354ECFCF797F3 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E4BDC2019F3FCDCE625C4504D08F0252 /* SEGAES256Crypto.h in Headers */ = {isa = PBXBuildFile; fileRef = DF7DA39664909AF7E002ABE7918BCB0A /* SEGAES256Crypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E7187E94A151E266C65F3AC055E2EE3D /* AMPRevenue.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A2D7F24D04260602A709FE7950272D2 /* AMPRevenue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E936C7018CCD992BF4E55C2F7B224706 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 4010254F0C43E3F606BCF2CF54F73DBA /* SPTCompiledExample.m */; };
-		E95DE019212836608A35BF3270AADF17 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D09826FF261A1E917BC82225E3F90C1B /* Expecta-dummy.m */; };
+		B709C0890B67EB6C1AB9B9738CDBEEC6 /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 890B4CD6376ABA26467B5F1D9F83C013 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B72D6F9CD6DCCF9339A269BC0CABA88C /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6CA514EAEB20514C511907E8917947 /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B7FB8C30C577D624F5E0B1FDB3E6CD8B /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = FC333AD1B7627E96142DCFDE17A30B62 /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B874982F26CB6C07AFAFC0C17226B4A7 /* UIViewController+SEGScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 59083081EB17BF3B6FA18C3D0E644203 /* UIViewController+SEGScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B913D18ECB8DD2C03C34E01200123773 /* AMPDatabaseHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 400149180DD517A0DFD70107487604C8 /* AMPDatabaseHelper.m */; };
+		B993F13DD56DF77BA97FC9CF49A671EF /* SEGAnalyticsUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 992CA22DFA136F4FD49D8E4A176613D0 /* SEGAnalyticsUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BAA98BF425D78B9F9FB405680EA0CB3D /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 00DC66922B064EB144FD148FDB38C6EF /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BB0E62892680D990AC167E4629F95062 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = CB1089573C5D78D1D9F4065D16C8A254 /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEB9C4C641EAB47778F648CC63EA9B4D /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7E64AA595D91F517C8F14DE8C3A28F /* SPTSpec.m */; };
+		BF3A4835EEF6AAE04527CD6C6A682F6C /* SEGFileStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = FB6B4F13A71EC73F837F2B7DD3C26DCE /* SEGFileStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C091203A57422574B3263D1E9BA53A87 /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F871E6E1D6517F0708558BED3F610B8 /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C26783210FE587F52DF3F587BDCA3832 /* SEGAliasPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 558FAACFCE9B9816440EEF640FD95833 /* SEGAliasPayload.m */; };
+		C3D1DB64E4A3EE65102EE6D9A6EFDBB4 /* AMPConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F4E64D6D8430AAEB01C516D700D5267 /* AMPConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C498F24E736A80A0F6C440DBC33AF494 /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4142BE023130309558EF01A65BA559C0 /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C64C4032827660F5ED12E425857BE673 /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 516FBEED0363BDC7AE882FD756AC663C /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C670343470EAC260E60ABD463CC39E2D /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = E631382627362D859C81669F86AEBF1A /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		C94A4613CC9925FF2001DFDA4CF6AB7C /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 87606149D989BB87D20275EDE8194667 /* SPTExampleGroup.m */; };
+		CAA9AE7CC0CFB7463ABA29294BE950B4 /* ISPPinnedNSURLConnectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E855BEE6E423D01699699C84B373AB8A /* ISPPinnedNSURLConnectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CC14BE1A09E4F4CF70C172273E2E6493 /* SEGAES256Crypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 64E3673979A4DF8EE8AC9CAEE772F531 /* SEGAES256Crypto.m */; };
+		CC962164B5364136CF8E00A74D4E8D63 /* SEGIdentifyPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 312BC14859AA982D73CABC8C95274558 /* SEGIdentifyPayload.m */; };
+		CC995F4F36E9D6237AFC6F729364B867 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E85857DE7F4AD479E44321A6C355 /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		CDA268F5B643324DD61A0E25BD4179ED /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A502F471FC784AB82CB1796D84D68D /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		CFADF209CAA4F83200AAA396001E227C /* Analytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F2D5B2C5AD2E82BABC5B945F8A376B9 /* Analytics-dummy.m */; };
+		D0DE286578576CD7CF4549D4DEE7A55C /* SEGUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = AF5B3D155B1DA4B3245F51DE14F6F237 /* SEGUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0FBACFDA11A4FBD836DADFDDB78E065 /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = B90C61E9442077359B2D916B1B0E7FEE /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D234263EFF5DB51E4FBA10414C8D1A70 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B89EA57522BBD61009D4D3D326BF6BA /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D3B4D194BECF709DFA85E588891B885E /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = 5821508B39F208764DE9C7C8EA13179A /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D8A629FB9E1A3A121FB1125453452844 /* SEGScreenPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B578D9F810C32D25A655729467931F0 /* SEGScreenPayload.m */; };
+		D94F3CDE976C052BF0BD112E257A7F19 /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 045247DCDD9A3BE74448A6A60A7B3C1C /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DA94B03B875E2F5EB229839CE5AFEFFD /* AMPURLSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 83AAF4FCC4701997C2327D6EC97EDF71 /* AMPURLSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC98C3CE439498B0039EF71B5A7C6FA0 /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 62AE75FBAAE05FCA79C3157E8B0534E8 /* SpectaUtility.m */; };
+		DE508A430274EB059C82112D80AEE297 /* SEGAliasPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = FBF1D69694C345057255DE4027C05181 /* SEGAliasPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFFE7035A8177E14B29DE53973AE3B1E /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 055D7680BB2A0FAFA5856B6B2A784942 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1CCAA1A4C2AA15743720F3BB98CE1F6 /* ISPCertificatePinning.h in Headers */ = {isa = PBXBuildFile; fileRef = E04665222996CFE32A931411D9A15E04 /* ISPCertificatePinning.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E35A7B447A624DA509D11A8B98DAB789 /* AMPDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DAA459F1E1D952F2400377515E2C921 /* AMPDeviceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4BDC2019F3FCDCE625C4504D08F0252 /* SEGAES256Crypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 5023796D5F6AE51F75FFEAB2D5A63F2A /* SEGAES256Crypto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E936C7018CCD992BF4E55C2F7B224706 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = B15A9E2382295010114AE017F335AEA8 /* SPTCompiledExample.m */; };
+		E95DE019212836608A35BF3270AADF17 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AC161BCA7674BCC44159C26CDBFE5E1 /* Expecta-dummy.m */; };
 		EA7C1F9BCD77BAC0600FF7B9FF7CE418 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
-		ECA3ED5D56B7625514FF1DCAE33BE9F3 /* SEGSegmentIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AE19A94029A969428AC1B9FCF48BA24 /* SEGSegmentIntegration.m */; };
-		ED087996824EE3256B222E3BAEBAB14D /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E597D8EFC41E4B3BC59184AFA88C1EF /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		EE5A8DD4F03A890084772DA66DE9BE93 /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = C06B31F31766322C502CAB6C6C2F92D8 /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECA3ED5D56B7625514FF1DCAE33BE9F3 /* SEGSegmentIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = AB6E092B63EA34D8E7F957F59F526445 /* SEGSegmentIntegration.m */; };
+		ED087996824EE3256B222E3BAEBAB14D /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB3AA995650C5069C380C7B2AA9C3EA /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		EE5A8DD4F03A890084772DA66DE9BE93 /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = C0203358C30C7D50BA9DDD504A84C3C8 /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EF35DCFA7C1415B234C58BC849F992B2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
-		EFCF1E2468BC28069F92B4702B5DD463 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 54D8915248E23900D0FE5028630DDF41 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F1AEDCED73DFC82CAB1D12DA9DE1CDE0 /* AMPUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 24EA7AE3B75F4C5093B1CDE708DE87EC /* AMPUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F264F1D7C4574896B15D365188D746E9 /* AMPConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 103DE9996136E45A545FB0CCC49CC25D /* AMPConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F3D6C90DF502E4B6BFA4B4B950FB176B /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DB325529B7A3863CD4392BBEDB2110B /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F59DCD21EF1B02CA179916ED58F8537D /* SEGHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D791A5995215B502A193FDC7473619F /* SEGHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EFCF1E2468BC28069F92B4702B5DD463 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 7331510219931D7EB298D2DB14D54CC8 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F27266EDE84CF2D787F8D12A2070DFCC /* AMPLocationManagerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 149A5419BEDCE361C45AF68F19551FA6 /* AMPLocationManagerDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F3D6C90DF502E4B6BFA4B4B950FB176B /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 13B75B9A32FE7161CF277BBE479A07DF /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F59DCD21EF1B02CA179916ED58F8537D /* SEGHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = B8E824DDC4B9F895070BE32C061E8BDF /* SEGHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7B20B4187947E3B6B93F0457C239D0B /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8960D86C5295BDF7B75BBDAAE0E08F9C /* XCTest.framework */; };
-		F8E39087737225714939DB0252FB1114 /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 54F461E9B166348306D21A44B4ADAFB4 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F93CE767C6CAEF68DFFBAA8989F40FB7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */; };
-		FD52D34CF159C0A543680DDDE0776EFA /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 496E777ED919382F084EA1AC9327D144 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FE84239BE923F217FD38E45B4F770EFD /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 2925DD16EB69EBCEE111DB2C2BA2CE81 /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FFC03DEB31C2082586AFFD991367F6ED /* ISPPinnedNSURLSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AF0B456B975B4173A82C5394B76B59D /* ISPPinnedNSURLSessionDelegate.m */; };
+		F7BA61AFF6A8C44FD36F97FBE460EB12 /* AMPUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E9290B3E2DE1E9A069BA003CF65E4210 /* AMPUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7D80768CC80821E1FBE756AB9CC344C /* AMPUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 366413D85AF2EAB2DA5741BB8827C64F /* AMPUtils.m */; };
+		F8E39087737225714939DB0252FB1114 /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = FD7631E18F4EA5CECA01ABE0629136B3 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FC92EB782AB4D2271AE246206166767A /* AMPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3EB0680BC7EB2FFE45E74E150A2A1E /* AMPConstants.m */; };
+		FD52D34CF159C0A543680DDDE0776EFA /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = B3C6D35DEAA0017CFCCFE9637D2686B8 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FE05FC5E6C50456F3788649E50A5C289 /* AMPIdentify.m in Sources */ = {isa = PBXBuildFile; fileRef = D83616CB59DD1D75C0B7EEC817D99351 /* AMPIdentify.m */; };
+		FE84239BE923F217FD38E45B4F770EFD /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F0DB86E7469DC751133C1052D05B2C0 /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -224,14 +226,14 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 001F28535027D76314F16FA8B0CB7C29;
+			remoteGlobalIDString = 1D45B8A36B1B88B0AEC790565370216C;
 			remoteInfo = "Amplitude-iOS";
 		};
 		A1A4A7CA33FB7FD98143CCE12341E666 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 001F28535027D76314F16FA8B0CB7C29;
+			remoteGlobalIDString = 1D45B8A36B1B88B0AEC790565370216C;
 			remoteInfo = "Amplitude-iOS";
 		};
 		BEDAD657BF70F7034260996F70EC60B8 /* PBXContainerItemProxy */ = {
@@ -258,229 +260,231 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		01480A7D9CBCBE893F37EEF86A8D104D /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
-		0245D4F7384198D81E95FB65F210D6D5 /* SEGGroupPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGGroupPayload.m; path = Analytics/Classes/Integrations/SEGGroupPayload.m; sourceTree = "<group>"; };
-		029E661288F5C15F610D9EF753C0522B /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
+		00DC66922B064EB144FD148FDB38C6EF /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
+		02FB07BABF1E9304C556734FD1D614B1 /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
+		037D39CEA5DC274C66042BFEA46945FD /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
 		03A89E41DB0004D7F414D45AE2C9863B /* Pods-Segment-Amplitude_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Amplitude_Example-frameworks.sh"; sourceTree = "<group>"; };
-		04C997D20AAE150754DC2D008D97C002 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
-		04D7611B749F0892496DBCA0A48ACF55 /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
-		052708A7CCE881EBBE100FC5D2A9576B /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
-		057CE4BDD50D52C36831D6C4432CE58E /* SEGAES256Crypto.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAES256Crypto.m; path = Analytics/Classes/Crypto/SEGAES256Crypto.m; sourceTree = "<group>"; };
-		062F1C5B07E68407382E548A171FEF0E /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
-		074A7F72471D17B9B39B2FD5A91BC047 /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
-		0B0135A3C0749A259EA98A8504132376 /* SEGUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGUtils.m; path = Analytics/Classes/Internal/SEGUtils.m; sourceTree = "<group>"; };
-		0CF93D12AF0BFAE9EC32A912522FA036 /* SEGStoreKitTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGStoreKitTracker.m; path = Analytics/Classes/Internal/SEGStoreKitTracker.m; sourceTree = "<group>"; };
-		0D6688073A8B98C99AFA0DAD52F38EA4 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
-		0DADC0B7BA89EEC028DDFED11BBAB9DA /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
-		0E45FD63A79F835DF60DC7B07B1BD240 /* AMPIdentify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPIdentify.m; path = Amplitude/AMPIdentify.m; sourceTree = "<group>"; };
-		0F895F4449950843D39F57D4C3A020B0 /* SEGStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGStorage.h; path = Analytics/Classes/Internal/SEGStorage.h; sourceTree = "<group>"; };
-		103DE9996136E45A545FB0CCC49CC25D /* AMPConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPConstants.h; path = Amplitude/AMPConstants.h; sourceTree = "<group>"; };
-		10550C05222935F9FC33D144292240FB /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
-		12F313B56D2FCFD91427AD8EB2C2E916 /* SEGTrackPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGTrackPayload.m; path = Analytics/Classes/Integrations/SEGTrackPayload.m; sourceTree = "<group>"; };
-		13C3D2412FF4B6BCF60D61F4C7B85E81 /* SEGHTTPClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGHTTPClient.m; path = Analytics/Classes/Internal/SEGHTTPClient.m; sourceTree = "<group>"; };
-		159FC513EC45B6CCD52AEFFCB7DA85BD /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
-		1827C80EB52169F66AADCF22D57C0F01 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
-		1AE19A94029A969428AC1B9FCF48BA24 /* SEGSegmentIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegration.m; path = Analytics/Classes/Internal/SEGSegmentIntegration.m; sourceTree = "<group>"; };
-		1C4C4D307678E2EB15890867D6B13A15 /* SEGAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalytics.m; path = Analytics/Classes/SEGAnalytics.m; sourceTree = "<group>"; };
-		1C83BEB5247FF766E2A486068177A78A /* SEGAliasPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAliasPayload.h; path = Analytics/Classes/Integrations/SEGAliasPayload.h; sourceTree = "<group>"; };
-		1D8A786B94C7E00341A80BF140AC9918 /* Amplitude.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Amplitude.h; path = Amplitude/Amplitude.h; sourceTree = "<group>"; };
-		1F0C6DD38DA9D5638A24CF31194BDD0C /* Amplitude+SSLPinning.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Amplitude+SSLPinning.h"; path = "Amplitude/Amplitude+SSLPinning.h"; sourceTree = "<group>"; };
+		045247DCDD9A3BE74448A6A60A7B3C1C /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
+		049666E8CB9D1EBE336D9FE1B8B36DA6 /* AMPRevenue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPRevenue.m; path = Amplitude/AMPRevenue.m; sourceTree = "<group>"; };
+		055D7680BB2A0FAFA5856B6B2A784942 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
+		07BD7C1EC40068C97F0FE12085EEE12A /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
+		0B578D9F810C32D25A655729467931F0 /* SEGScreenPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGScreenPayload.m; path = Analytics/Classes/Integrations/SEGScreenPayload.m; sourceTree = "<group>"; };
+		0BACD39777742EB692EEA6B0E2B6B8FE /* ISPCertificatePinning.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ISPCertificatePinning.m; path = Amplitude/SSLCertificatePinning/ISPCertificatePinning.m; sourceTree = "<group>"; };
+		0C62328863DF9BD01E9270A3B882B436 /* Amplitude.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Amplitude.h; path = Amplitude/Amplitude.h; sourceTree = "<group>"; };
+		0F0FE2B5A0B556A439AF293EA85F7D79 /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
+		106B4700274B0FBFE7EB79FB5A45112D /* AMPDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPDeviceInfo.m; path = Amplitude/AMPDeviceInfo.m; sourceTree = "<group>"; };
+		114FF9105326AB0F3517997351EBCC69 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
+		12EFBD73F6A98774AB16D5F36AB1657F /* SEGTrackPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGTrackPayload.m; path = Analytics/Classes/Integrations/SEGTrackPayload.m; sourceTree = "<group>"; };
+		13482F8367E43FE70F1A3756B1E59862 /* NSData+SEGGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+SEGGZIP.h"; path = "Analytics/Classes/Internal/NSData+SEGGZIP.h"; sourceTree = "<group>"; };
+		13B75B9A32FE7161CF277BBE479A07DF /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
+		149A5419BEDCE361C45AF68F19551FA6 /* AMPLocationManagerDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPLocationManagerDelegate.h; path = Amplitude/AMPLocationManagerDelegate.h; sourceTree = "<group>"; };
+		1A3E8E355E79BDBF6AA673C82EB1488C /* SEGIdentifyPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIdentifyPayload.h; path = Analytics/Classes/Integrations/SEGIdentifyPayload.h; sourceTree = "<group>"; };
+		1AC292D2AD17D32A41AA8F215552057E /* Amplitude-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Amplitude-iOS-dummy.m"; sourceTree = "<group>"; };
+		1AFC0F9D3BE9D166BC76B017F6047DDD /* SEGAnalyticsUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsUtils.m; path = Analytics/Classes/Internal/SEGAnalyticsUtils.m; sourceTree = "<group>"; };
+		1B49E45FBA8888E6B080D272C4E2D82C /* SEGTrackPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGTrackPayload.h; path = Analytics/Classes/Integrations/SEGTrackPayload.h; sourceTree = "<group>"; };
 		1F61AE1AA422FE9F77518DD127E3E010 /* libAmplitude-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libAmplitude-iOS.a"; path = "libAmplitude-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2016D9062A4D08C4EFDB187517DDD55A /* SEGContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGContext.h; path = Analytics/Classes/Middlewares/SEGContext.h; sourceTree = "<group>"; };
-		211C04DC2D1B25A68A8E22F74EE9A1B5 /* SEGIntegrationsManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIntegrationsManager.m; path = Analytics/Classes/Integrations/SEGIntegrationsManager.m; sourceTree = "<group>"; };
-		22D9B27E3593B4FE7E6F1E31FDF5BF31 /* SEGUserDefaultsStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGUserDefaultsStorage.h; path = Analytics/Classes/Internal/SEGUserDefaultsStorage.h; sourceTree = "<group>"; };
-		23353B63CC7BA6791AD8A80B65C560F5 /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
-		23E622EC871443CB64E795D87CC3EB8F /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
-		244ACD2F7A8506674928052A373C222A /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
-		24EA7AE3B75F4C5093B1CDE708DE87EC /* AMPUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPUtils.h; path = Amplitude/AMPUtils.h; sourceTree = "<group>"; };
-		2569283733FA66D4BCD8B9CE107C1ED1 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
-		2925DD16EB69EBCEE111DB2C2BA2CE81 /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
+		1FCAE1E4DC842EFCA104FC26C666733E /* SEGSerializableValue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSerializableValue.h; path = Analytics/Classes/SEGSerializableValue.h; sourceTree = "<group>"; };
+		21CF6CA8D88D7E8BBFEB5D6317F6FA8F /* SEGMiddleware.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGMiddleware.h; path = Analytics/Classes/Middlewares/SEGMiddleware.h; sourceTree = "<group>"; };
+		2601D11F4D446F8940EAF29716212E6E /* SEGIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegration.h; path = Analytics/Classes/Integrations/SEGIntegration.h; sourceTree = "<group>"; };
+		27205BEE57D0EF3AD7ACB7ECB8AC2ACB /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
+		277128513D3F88935753AABDEF48C2E6 /* SEGUserDefaultsStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGUserDefaultsStorage.h; path = Analytics/Classes/Internal/SEGUserDefaultsStorage.h; sourceTree = "<group>"; };
+		2846E10F9BF1609A4DA7F0E08EDFC2BF /* SEGUserDefaultsStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGUserDefaultsStorage.m; path = Analytics/Classes/Internal/SEGUserDefaultsStorage.m; sourceTree = "<group>"; };
+		28D7F35F2E6AF80FDEB18D7EC82B4675 /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
 		294F0F58FC81E22F3FD9D25767F23C32 /* SEGAmplitudeIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SEGAmplitudeIntegrationFactory.h; sourceTree = "<group>"; };
-		2DA2CE5A5C54DC8DE8843ECC48238783 /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
-		30059F086F05B2FA99DD533F5FCD0A1E /* SEGTrackPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGTrackPayload.h; path = Analytics/Classes/Integrations/SEGTrackPayload.h; sourceTree = "<group>"; };
-		30ECA58326290498D458ABD7E37FF021 /* ISPCertificatePinning.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISPCertificatePinning.h; path = Amplitude/SSLCertificatePinning/ISPCertificatePinning.h; sourceTree = "<group>"; };
-		319CD8F9255AB12DC3E5500AA4A7277E /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
-		34981AF8FD0AA321CE63B26FF54AFBF8 /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
-		349E06C875B231081A714DC34B9E8F70 /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
+		2AC161BCA7674BCC44159C26CDBFE5E1 /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
+		2B29D3397DD8F4BD4594A0BAA6F396B7 /* SEGAnalyticsConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsConfiguration.m; path = Analytics/Classes/SEGAnalyticsConfiguration.m; sourceTree = "<group>"; };
+		2B40FF86BB1EAC4DF28AE8D59884679B /* Analytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Analytics-prefix.pch"; sourceTree = "<group>"; };
+		2D922C3CFE46CE8B2BAFBC23E7BA316D /* Amplitude.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = Amplitude.m; path = Amplitude/Amplitude.m; sourceTree = "<group>"; };
+		2DC86C19A8B9CA748D479F727FEC9BE1 /* ComodoRsaDomainValidationCA.der */ = {isa = PBXFileReference; includeInIndex = 1; name = ComodoRsaDomainValidationCA.der; path = Amplitude/ComodoRsaDomainValidationCA.der; sourceTree = "<group>"; };
+		2EAB98B9DEB4AB708653F15889D263A9 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
+		3068851374CC58D083398FDC1F834B05 /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
+		312BC14859AA982D73CABC8C95274558 /* SEGIdentifyPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIdentifyPayload.m; path = Analytics/Classes/Integrations/SEGIdentifyPayload.m; sourceTree = "<group>"; };
+		32852763DA17CC6C9650F629D2A1A429 /* SEGAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalytics.h; path = Analytics/Classes/SEGAnalytics.h; sourceTree = "<group>"; };
+		342018E29907F78799D523D920D3EF5E /* Amplitude+SSLPinning.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Amplitude+SSLPinning.h"; path = "Amplitude/Amplitude+SSLPinning.h"; sourceTree = "<group>"; };
 		34C72199DA55BDE05D590F2443B92785 /* Segment-Amplitude.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Segment-Amplitude.xcconfig"; sourceTree = "<group>"; };
-		35CDA8795091411CBBAE195C039E8222 /* SEGMiddleware.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGMiddleware.h; path = Analytics/Classes/Middlewares/SEGMiddleware.h; sourceTree = "<group>"; };
-		383D4A452F00117A26C971A8B572188A /* ISPPinnedNSURLConnectionDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ISPPinnedNSURLConnectionDelegate.m; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLConnectionDelegate.m; sourceTree = "<group>"; };
-		391E38B40014B3C5AE2649E5BB162657 /* SEGReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGReachability.m; path = Analytics/Classes/Internal/SEGReachability.m; sourceTree = "<group>"; };
+		366413D85AF2EAB2DA5741BB8827C64F /* AMPUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPUtils.m; path = Amplitude/AMPUtils.m; sourceTree = "<group>"; };
+		3898DE5D367DF8E7F5799BD2C9E7A0B5 /* Amplitude-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Amplitude-iOS.xcconfig"; sourceTree = "<group>"; };
+		3AA117E301657060FAF000750A593A31 /* SEGStoreKitTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGStoreKitTracker.h; path = Analytics/Classes/Internal/SEGStoreKitTracker.h; sourceTree = "<group>"; };
 		3AD179D8489552FEDA337D7DBB99E93A /* Segment-Amplitude-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Segment-Amplitude-prefix.pch"; sourceTree = "<group>"; };
-		3C14F0FB1BD4B13E096EC7F35FC74441 /* SEGReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGReachability.h; path = Analytics/Classes/Internal/SEGReachability.h; sourceTree = "<group>"; };
-		3C8FCF193AEFBCCA25FFF87324CF62DE /* NSData+SEGGZIP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+SEGGZIP.h"; path = "Analytics/Classes/Internal/NSData+SEGGZIP.h"; sourceTree = "<group>"; };
-		3F8A2CB61EA957F84C62D74D090E3A2F /* SEGSegmentIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegration.h; path = Analytics/Classes/Internal/SEGSegmentIntegration.h; sourceTree = "<group>"; };
-		4010254F0C43E3F606BCF2CF54F73DBA /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
-		407630499F85D93A69E7AF248DA6ED49 /* ISPPinnedNSURLSessionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISPPinnedNSURLSessionDelegate.h; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLSessionDelegate.h; sourceTree = "<group>"; };
-		41FD8F7ECD70A1B0DEB7A663FD6AEE37 /* UIViewController+SEGScreen.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+SEGScreen.m"; path = "Analytics/Classes/Internal/UIViewController+SEGScreen.m"; sourceTree = "<group>"; };
-		426EC199E1D780EE7F9889E140D03AF3 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
-		42A11F8A655956BD0ECBF23D916DF693 /* SEGIdentifyPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIdentifyPayload.m; path = Analytics/Classes/Integrations/SEGIdentifyPayload.m; sourceTree = "<group>"; };
-		42A56A8F8C726F86F98F0CE6982607D1 /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		42C40EB2DCFD06A0C6F301FBD3779C67 /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
-		463B99F50CCAD25F5EAA7EA8D9D72970 /* AMPIdentify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPIdentify.h; path = Amplitude/AMPIdentify.h; sourceTree = "<group>"; };
-		496E777ED919382F084EA1AC9327D144 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		49F1C871CFAC83BA29C085AE37AB8CE1 /* Amplitude-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Amplitude-iOS-prefix.pch"; sourceTree = "<group>"; };
-		4AF0B456B975B4173A82C5394B76B59D /* ISPPinnedNSURLSessionDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ISPPinnedNSURLSessionDelegate.m; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLSessionDelegate.m; sourceTree = "<group>"; };
-		4AFBF8397123195FC2207F60E5EC35EB /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
+		3DF719B6D31E9F52D5329D17B4705148 /* Analytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Analytics.xcconfig; sourceTree = "<group>"; };
+		3FE56EFE03C000589BBC46DC061FF713 /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
+		400149180DD517A0DFD70107487604C8 /* AMPDatabaseHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPDatabaseHelper.m; path = Amplitude/AMPDatabaseHelper.m; sourceTree = "<group>"; };
+		4142BE023130309558EF01A65BA559C0 /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
+		439659C5E707F12F8FF8D9377D22DC12 /* AMPLocationManagerDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPLocationManagerDelegate.m; path = Amplitude/AMPLocationManagerDelegate.m; sourceTree = "<group>"; };
+		4455E03C82E46FE5D20A30630A3ADD46 /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
+		4476A3BC8005F9AA025A4C79112746FA /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
+		447C54C123E313B6D12066A7C9D1BE60 /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
+		469035B8DA115714C2F921BA21D53A60 /* AMPURLConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPURLConnection.h; path = Amplitude/AMPURLConnection.h; sourceTree = "<group>"; };
+		486E670BE7029ECAE44C8FB8B3422DD6 /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
+		48AB5F7F336A88CD4CB881C8778B39B3 /* ComodoRsaCA.der */ = {isa = PBXFileReference; includeInIndex = 1; name = ComodoRsaCA.der; path = Amplitude/ComodoRsaCA.der; sourceTree = "<group>"; };
+		4965FF0C8B97FDC1BFCCEEB48A4009AF /* AMPURLSession.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPURLSession.m; path = Amplitude/AMPURLSession.m; sourceTree = "<group>"; };
+		4A2504FB7A69B6D51A64C2D15DFE4FDD /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
+		4B3B423BA8A318512E8E54ADE4314BB5 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
 		4CF250516F4030814DF72DA39CADACD6 /* SEGAmplitudeIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SEGAmplitudeIntegration.m; sourceTree = "<group>"; };
-		4D01DE19A9AF6EEE3EE27FD208E8E204 /* Amplitude.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = Amplitude.m; path = Amplitude/Amplitude.m; sourceTree = "<group>"; };
-		4ED2CF514643512E05408DFF013A2BE6 /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
+		4DAA459F1E1D952F2400377515E2C921 /* AMPDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPDeviceInfo.h; path = Amplitude/AMPDeviceInfo.h; sourceTree = "<group>"; };
+		4E6A73E02028A9E00279952D23CB9FED /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
+		4F7E64AA595D91F517C8F14DE8C3A28F /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
+		5023796D5F6AE51F75FFEAB2D5A63F2A /* SEGAES256Crypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAES256Crypto.h; path = Analytics/Classes/Crypto/SEGAES256Crypto.h; sourceTree = "<group>"; };
 		506305E384D8649522C457A759AC24B9 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		535E6FE9F09EE7A34A7AA0B24CFA224C /* SEGAnalyticsConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsConfiguration.h; path = Analytics/Classes/SEGAnalyticsConfiguration.h; sourceTree = "<group>"; };
+		516FBEED0363BDC7AE882FD756AC663C /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
+		530328B68CED82B0D989DB7D28979581 /* SEGContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGContext.h; path = Analytics/Classes/Middlewares/SEGContext.h; sourceTree = "<group>"; };
 		53CFBBC6D7A5CDBA19C585DD646360C3 /* libSegment-Amplitude.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libSegment-Amplitude.a"; path = "libSegment-Amplitude.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		54D8915248E23900D0FE5028630DDF41 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
-		54E4323B155EE86D7930101B5D6D72CF /* Amplitude-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Amplitude-iOS.xcconfig"; sourceTree = "<group>"; };
-		54F461E9B166348306D21A44B4ADAFB4 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
-		564D7B2B174AB666A303BC00345E11F6 /* SEGCrypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGCrypto.h; path = Analytics/Classes/Crypto/SEGCrypto.h; sourceTree = "<group>"; };
-		56D50CD8694ACABA962CEA56EB52E318 /* AMPDeviceInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPDeviceInfo.h; path = Amplitude/AMPDeviceInfo.h; sourceTree = "<group>"; };
-		58A06AAF545D60E532B5E580D8575E4B /* AMPRevenue.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPRevenue.m; path = Amplitude/AMPRevenue.m; sourceTree = "<group>"; };
-		5A2D7F24D04260602A709FE7950272D2 /* AMPRevenue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPRevenue.h; path = Amplitude/AMPRevenue.h; sourceTree = "<group>"; };
-		5ABFC2270C607240D03045B116D23D99 /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
-		5B10F2102C350F346E1B322A2FF23DCD /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
-		5B59B4359A00BAA62A4056EF8E7A2923 /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
-		5DB325529B7A3863CD4392BBEDB2110B /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
-		5F699F59178DA3C46F68433B6281BC57 /* AMPDeviceInfo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPDeviceInfo.m; path = Amplitude/AMPDeviceInfo.m; sourceTree = "<group>"; };
-		62BFD73EE1987F0FECC76F506D9891D4 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
-		650C921B0925E66C82CC3E9F933C44B5 /* ComodoRsaDomainValidationCA.der */ = {isa = PBXFileReference; includeInIndex = 1; name = ComodoRsaDomainValidationCA.der; path = Amplitude/ComodoRsaDomainValidationCA.der; sourceTree = "<group>"; };
+		541F0E672A7801C26E964E01B514852F /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
+		558FAACFCE9B9816440EEF640FD95833 /* SEGAliasPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAliasPayload.m; path = Analytics/Classes/Integrations/SEGAliasPayload.m; sourceTree = "<group>"; };
+		5821508B39F208764DE9C7C8EA13179A /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
+		59083081EB17BF3B6FA18C3D0E644203 /* UIViewController+SEGScreen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+SEGScreen.h"; path = "Analytics/Classes/Internal/UIViewController+SEGScreen.h"; sourceTree = "<group>"; };
+		5A6CA514EAEB20514C511907E8917947 /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
+		5C1E9A6CE1C5CE2A2940D0C39384385B /* SEGStoreKitTracker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGStoreKitTracker.m; path = Analytics/Classes/Internal/SEGStoreKitTracker.m; sourceTree = "<group>"; };
+		5C311E99953DBE59C3D36FF8313E7DD6 /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
+		5DA534F4A25B3D8D7DEB7FB04D7DA2EF /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
+		5F11B1E66913BA1E16E10B0AC7F6A094 /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
+		6073F569662785196B3A57674CCABD27 /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
+		62AE75FBAAE05FCA79C3157E8B0534E8 /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
+		62CAEACD6EDC65D6C2E189E7FFBACE3F /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
+		6388B8E2B5D07C3F842D48F79BA6F4F3 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
+		64B24A9D559159DBFA62E28E21D24F45 /* ComodoCaLimitedRsaCertificationAuthority.der */ = {isa = PBXFileReference; includeInIndex = 1; name = ComodoCaLimitedRsaCertificationAuthority.der; path = Amplitude/ComodoCaLimitedRsaCertificationAuthority.der; sourceTree = "<group>"; };
+		64E3673979A4DF8EE8AC9CAEE772F531 /* SEGAES256Crypto.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAES256Crypto.m; path = Analytics/Classes/Crypto/SEGAES256Crypto.m; sourceTree = "<group>"; };
 		65BA7783E08EFB7B22315788FBDF00AF /* Pods-Segment-Amplitude_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Segment-Amplitude_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		669471B098D52AED0FAF3BBB2F239C1F /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
-		670C6376CF3221E88A973FA56828596A /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
-		68103AF3D0F9D0B3F8A870030B2B7622 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
-		683CAC4BA6B707B65F2326EAFFB2CDCA /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
-		69642322049325A5D69C9757E58D4960 /* Analytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Analytics-prefix.pch"; sourceTree = "<group>"; };
-		6AFD81A519442C17BD66D4CF6869208D /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
-		6CAFB6BACDAF3A80C523ABAFCBF7DB3B /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
-		6CB44D917789B23A1069A81835C8D3A8 /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
+		66525BDE0651DE1CBEF16B921CDF1F6F /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
+		697A8911084F828C89B4829E1BEF6A30 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
+		6A13A5BD9AEFB9B1BCA7787A71B5BDC0 /* SEGHTTPClient.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGHTTPClient.m; path = Analytics/Classes/Internal/SEGHTTPClient.m; sourceTree = "<group>"; };
+		6A6F256393F6A7EFE7ED6239F9F6ED46 /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
+		6B89EA57522BBD61009D4D3D326BF6BA /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
 		6E22C2C0374B11EC62B4AB44C53D8A5D /* Pods-Segment-Amplitude_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Amplitude_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		733E054797F042C3899A8835485E84E9 /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
-		775B24803BDB4696043B72B523099331 /* SEGIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationFactory.h; path = Analytics/Classes/Integrations/SEGIntegrationFactory.h; sourceTree = "<group>"; };
-		7898DBA0A41336906E5CC5DD30A0CA7F /* SEGAnalyticsUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsUtils.h; path = Analytics/Classes/Internal/SEGAnalyticsUtils.h; sourceTree = "<group>"; };
-		7AA96730930522599FDCF58FD5822C3C /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
+		6E54D5395053660ED0C4CCD8EDBCE2CD /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
+		7331510219931D7EB298D2DB14D54CC8 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
+		73BB01A277F8526FE777A73707F7076A /* SEGMiddleware.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGMiddleware.m; path = Analytics/Classes/Middlewares/SEGMiddleware.m; sourceTree = "<group>"; };
+		768E730FF9F2CA87AC264B37D6D28F37 /* SEGCrypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGCrypto.h; path = Analytics/Classes/Crypto/SEGCrypto.h; sourceTree = "<group>"; };
+		76C307D7FC8D3AA8ADC048D811E3676C /* ISPPinnedNSURLSessionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISPPinnedNSURLSessionDelegate.h; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLSessionDelegate.h; sourceTree = "<group>"; };
+		79F45ECA8987D0089E95769120E5A740 /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
 		7BB8510DA94A130308CA4B3551552CBE /* SEGAmplitudeIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SEGAmplitudeIntegration.h; sourceTree = "<group>"; };
-		7D9C73F07D5ED825725897F344AD37D7 /* AMPDatabaseHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPDatabaseHelper.m; path = Amplitude/AMPDatabaseHelper.m; sourceTree = "<group>"; };
-		7E4D103CAE09CC3696359FC39E1DC405 /* SEGUserDefaultsStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGUserDefaultsStorage.m; path = Analytics/Classes/Internal/SEGUserDefaultsStorage.m; sourceTree = "<group>"; };
-		7E597D8EFC41E4B3BC59184AFA88C1EF /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
-		811047735893AECD2736A9A99732CB9C /* AMPDatabaseHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPDatabaseHelper.h; path = Amplitude/AMPDatabaseHelper.h; sourceTree = "<group>"; };
-		813CA4C07945BE63470A05648C78435E /* api.amplitude.com.der */ = {isa = PBXFileReference; includeInIndex = 1; name = api.amplitude.com.der; path = Amplitude/api.amplitude.com.der; sourceTree = "<group>"; };
+		7BB94DC2E803F41549F32ADDF85110E7 /* SEGScreenPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGScreenPayload.h; path = Analytics/Classes/Integrations/SEGScreenPayload.h; sourceTree = "<group>"; };
+		7F0DB86E7469DC751133C1052D05B2C0 /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
 		815B0312398080152097D8BE1CDCF1C4 /* Pods-Segment-Amplitude_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Amplitude_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		818103592EEE2F0699560E22A2283FA9 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
-		81D5FADF1DDB8237256230366055DE7B /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
-		81E8E1ED0B06B95947FF1950C097937F /* SEGIdentifyPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIdentifyPayload.h; path = Analytics/Classes/Integrations/SEGIdentifyPayload.h; sourceTree = "<group>"; };
-		826EB24E197AEE07B0F1A40AF42E9E24 /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
 		83457AD773667130606948E9539398F6 /* Pods-Segment-Amplitude_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Amplitude_Example.release.xcconfig"; sourceTree = "<group>"; };
-		8410116518AC02B7B7FA8E1C72DFB851 /* ISPCertificatePinning.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ISPCertificatePinning.m; path = Amplitude/SSLCertificatePinning/ISPCertificatePinning.m; sourceTree = "<group>"; };
-		852F41FE0DEC18E699B7C269B3B087A2 /* SEGAnalyticsUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsUtils.m; path = Analytics/Classes/Internal/SEGAnalyticsUtils.m; sourceTree = "<group>"; };
+		83A0B0BFEC9A20036CF5D2DA955A9416 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
+		83AAF4FCC4701997C2327D6EC97EDF71 /* AMPURLSession.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPURLSession.h; path = Amplitude/AMPURLSession.h; sourceTree = "<group>"; };
+		85C54A5B9CBFC10D616BB614A3809648 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
 		8659B014C4899829EC0A3A36E086C85B /* Pods-Segment-Amplitude_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Segment-Amplitude_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		887A060C2E187B4063B3DCBFEF4447E0 /* SEGFileStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGFileStorage.m; path = Analytics/Classes/Internal/SEGFileStorage.m; sourceTree = "<group>"; };
+		87300EAB4B8D40E44664C39237A572A4 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
+		87606149D989BB87D20275EDE8194667 /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
+		88F6E85857DE7F4AD479E44321A6C355 /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
+		890B4CD6376ABA26467B5F1D9F83C013 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
 		8960D86C5295BDF7B75BBDAAE0E08F9C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		89B0DDC1955FD9DCC7BD743F81DD67EC /* Pods-Segment-Amplitude_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Amplitude_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		8B3265087784501F7BE4519246D7587E /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
-		8CA6702B35516C5F8DB5D7827B1D3106 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
-		8D8E7A6E4840BA29E0A4149F853864C1 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
-		90DE6A11107EDD0F3236A7191A03ACB2 /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
-		92E7E223FB84E9BB010C15000FEEA0E2 /* SEGIntegrationsManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationsManager.h; path = Analytics/Classes/Integrations/SEGIntegrationsManager.h; sourceTree = "<group>"; };
+		8B23CB2BF8335FD971D75F9E70E11672 /* NSData+SEGGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+SEGGZIP.m"; path = "Analytics/Classes/Internal/NSData+SEGGZIP.m"; sourceTree = "<group>"; };
+		8BC97FE030D6C6FC932A65C612CF70A9 /* SEGIntegrationsManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIntegrationsManager.m; path = Analytics/Classes/Integrations/SEGIntegrationsManager.m; sourceTree = "<group>"; };
+		8CA660ECD5289B2E9F913D6BFB187FA7 /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
+		8D4FC7ABCD2E0489967F7ED31C490964 /* AMPARCMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPARCMacros.h; path = Amplitude/AMPARCMacros.h; sourceTree = "<group>"; };
+		8F0062B708509828C55C300839C07908 /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
+		904651D94A1EC833EB0895379DF77C54 /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
+		91B36DC084E95D0276C05B3696031C48 /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
+		91F2424E9BA318B7BE3666EBA199DB4E /* UIViewController+SEGScreen.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+SEGScreen.m"; path = "Analytics/Classes/Internal/UIViewController+SEGScreen.m"; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		94FD2853D0A0D17EBC31540ED4F0AAD9 /* AMPURLConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPURLConnection.m; path = Amplitude/AMPURLConnection.m; sourceTree = "<group>"; };
 		958BBB4F4D8B7B53478A9955445E11CB /* Pods-Segment-Amplitude_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Segment-Amplitude_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		95CDF764B3AB9BEF612C6FE52DBEBBB2 /* SEGAliasPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAliasPayload.m; path = Analytics/Classes/Integrations/SEGAliasPayload.m; sourceTree = "<group>"; };
-		973EF3AA585F3267168AF659D90CDB74 /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
-		9791B1C154ABB159E483EC759C5D7A0D /* SEGStoreKitTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGStoreKitTracker.h; path = Analytics/Classes/Internal/SEGStoreKitTracker.h; sourceTree = "<group>"; };
-		9A1ED211388C33C2B02FB3B847D5FEEC /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
-		9A2418FDACE26FD5D9FB10B6DD6354AD /* SEGMiddleware.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGMiddleware.m; path = Analytics/Classes/Middlewares/SEGMiddleware.m; sourceTree = "<group>"; };
-		9BC3C426DCD8089601C1B6528A19AF8A /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
-		9BD36129947FA0AA12F7D4F8EB940E56 /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
-		9C6479793D1B08323285DCF6969FBE89 /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
-		9C7ECE7F16091058BFF65B4E6DF256DF /* SEGContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGContext.m; path = Analytics/Classes/Middlewares/SEGContext.m; sourceTree = "<group>"; };
-		9CAC9B15CF6343964FE25817C5243620 /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
-		9D791A5995215B502A193FDC7473619F /* SEGHTTPClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGHTTPClient.h; path = Analytics/Classes/Internal/SEGHTTPClient.h; sourceTree = "<group>"; };
-		9DE4B1D248315C223B3A581F8E079024 /* UIViewController+SEGScreen.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+SEGScreen.h"; path = "Analytics/Classes/Internal/UIViewController+SEGScreen.h"; sourceTree = "<group>"; };
+		95C6E99E732850A4A8F2B696A01C2235 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
+		98673472A9C5E362EDCAC00FD68E264E /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
+		992CA22DFA136F4FD49D8E4A176613D0 /* SEGAnalyticsUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsUtils.h; path = Analytics/Classes/Internal/SEGAnalyticsUtils.h; sourceTree = "<group>"; };
+		9AE62F76045AD19E5321C9291DE7F5A1 /* Amplitude-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Amplitude-iOS-prefix.pch"; sourceTree = "<group>"; };
+		9C3EB0680BC7EB2FFE45E74E150A2A1E /* AMPConstants.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPConstants.m; path = Amplitude/AMPConstants.m; sourceTree = "<group>"; };
+		9CB3AA995650C5069C380C7B2AA9C3EA /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
 		9DE8F466995879876CCF7D846983D996 /* Pods-Segment-Amplitude_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Amplitude_Tests-resources.sh"; sourceTree = "<group>"; };
-		A265ABE8989F2FFF05C1A0CFC8D71945 /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
-		A50B67FF1D6096FC9872483DC8E2EA0D /* SEGScreenPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGScreenPayload.m; path = Analytics/Classes/Integrations/SEGScreenPayload.m; sourceTree = "<group>"; };
+		9E93604C6325CF2806F5AFAF2D135214 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
+		9EB8345DC7265292F389D3485E3ACDAA /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
+		9F2D5B2C5AD2E82BABC5B945F8A376B9 /* Analytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Analytics-dummy.m"; sourceTree = "<group>"; };
+		9F4E64D6D8430AAEB01C516D700D5267 /* AMPConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPConstants.h; path = Amplitude/AMPConstants.h; sourceTree = "<group>"; };
+		9F871E6E1D6517F0708558BED3F610B8 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
+		A00AB0401B5B51D3D6FE7C3E1C66B8BE /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
+		A1CCB973F606819CC7C2A7DB16FF383B /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
+		A538DE0A412504C66899D007094F833D /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
+		A5521A048F5A31ADBD0B40AF8883E83C /* api.amplitude.com.der */ = {isa = PBXFileReference; includeInIndex = 1; name = api.amplitude.com.der; path = Amplitude/api.amplitude.com.der; sourceTree = "<group>"; };
+		A6A39483C7584E1F98C518913C94CECF /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
+		A72B4ED9BE22367B0C80D360DE43A738 /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
 		A79A58A113639F2161F1296A884EC07F /* libPods-Segment-Amplitude_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-Segment-Amplitude_Tests.a"; path = "libPods-Segment-Amplitude_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A80CE8B4914733F05FA29D5E6EC1A075 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
-		A82B9E07D3CC1758AB734ED138878DCA /* ISPPinnedNSURLConnectionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISPPinnedNSURLConnectionDelegate.h; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLConnectionDelegate.h; sourceTree = "<group>"; };
+		A7E26ED2242DC4C7BBE47EB62E399A38 /* SEGContext.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGContext.m; path = Analytics/Classes/Middlewares/SEGContext.m; sourceTree = "<group>"; };
+		AA2240B5CBAA31E45426F2615A5F65A7 /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
+		AB6E092B63EA34D8E7F957F59F526445 /* SEGSegmentIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegration.m; path = Analytics/Classes/Internal/SEGSegmentIntegration.m; sourceTree = "<group>"; };
 		ABF26D4EC7C89B970E71A28E52A8D167 /* Pods-Segment-Amplitude_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-Amplitude_Example-resources.sh"; sourceTree = "<group>"; };
-		AC710D09972E764BC5D2F36D869DABA3 /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
 		AD2B51B9DF1EB6EBD5C6AE262275806A /* Pods-Segment-Amplitude_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Segment-Amplitude_Example-dummy.m"; sourceTree = "<group>"; };
-		AE9536CC20968448AEB856438F0FE8E5 /* SEGIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegration.h; path = Analytics/Classes/Integrations/SEGIntegration.h; sourceTree = "<group>"; };
-		B22DF54B7066123934BD64EC79F0E751 /* Analytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Analytics.xcconfig; sourceTree = "<group>"; };
-		B352EF08411BAB450770E6E407CCEE55 /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
-		B399ED8120CE53B322DD036276714A7E /* AMPConstants.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPConstants.m; path = Amplitude/AMPConstants.m; sourceTree = "<group>"; };
+		AF5B3D155B1DA4B3245F51DE14F6F237 /* SEGUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGUtils.h; path = Analytics/Classes/Internal/SEGUtils.h; sourceTree = "<group>"; };
+		B07DCAFE90418B6612216ACFA3E804EA /* SEGAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalytics.m; path = Analytics/Classes/SEGAnalytics.m; sourceTree = "<group>"; };
+		B15A9E2382295010114AE017F335AEA8 /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
+		B22B6EEAA9F357DCDCF57019CACE60FD /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
+		B339E4D939EF4F6434767CF492722E7A /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
+		B3C6D35DEAA0017CFCCFE9637D2686B8 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
+		B54549AE2FB2CA5C171A7570CC94E0DF /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
 		B571ABBAD558ACE1F43D77E97FCA9CC8 /* Segment-Amplitude-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Segment-Amplitude-dummy.m"; sourceTree = "<group>"; };
 		B5A6F093B825E61FB0E72EBADC74BEC8 /* Pods-Segment-Amplitude_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Segment-Amplitude_Tests-dummy.m"; sourceTree = "<group>"; };
-		B84AFD134B3A2F20C256F4CC4DCF5EDD /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
-		B87CB82AEE07830FD01226B42F26BEFB /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
-		B89E639E443D6A119B1354ECFCF797F3 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
-		B910263EE03D2C9834FFBCC0C953AB8E /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
-		BA03B2E04B17DB398ADD5C7688CDBF82 /* NSData+SEGGZIP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+SEGGZIP.m"; path = "Analytics/Classes/Internal/NSData+SEGGZIP.m"; sourceTree = "<group>"; };
-		BABCB9B2DC83996225AA8ABCE5BA6F5A /* SEGAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalytics.h; path = Analytics/Classes/SEGAnalytics.h; sourceTree = "<group>"; };
+		B75945B18D32221F79504A270FCB9E92 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
+		B8E824DDC4B9F895070BE32C061E8BDF /* SEGHTTPClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGHTTPClient.h; path = Analytics/Classes/Internal/SEGHTTPClient.h; sourceTree = "<group>"; };
+		B90C61E9442077359B2D916B1B0E7FEE /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
+		B93FEF6ADEF7DB5BCDE84F78927CB62F /* SEGStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGStorage.h; path = Analytics/Classes/Internal/SEGStorage.h; sourceTree = "<group>"; };
+		B95634D2C2A67A4044B32F32B6F35BC8 /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
 		BAF87A33CBA25CE8094BD44C07705543 /* libPods-Segment-Amplitude_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-Segment-Amplitude_Example.a"; path = "libPods-Segment-Amplitude_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BBBA8ED4F916BC134AC1AFF7BDEE5082 /* AMPLocationManagerDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPLocationManagerDelegate.m; path = Amplitude/AMPLocationManagerDelegate.m; sourceTree = "<group>"; };
-		BCC428E1754486F4215F62E74C6387F0 /* AMPURLConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPURLConnection.m; path = Amplitude/AMPURLConnection.m; sourceTree = "<group>"; };
 		BDF03CD9810A6F1BC33CA3F28AD56302 /* libExpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libExpecta.a; path = libExpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		BF8FF5C73BB79B423731E0905C8AC6CB /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
-		C06B31F31766322C502CAB6C6C2F92D8 /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
-		C22B1B3B9FEBE179CC63DFB3E09852BD /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
-		C3F06A32ADD89B7686A0D540F7E44AF4 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
+		BE80018AFD761E1C8BCCB18C903636EE /* SEGGroupPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGGroupPayload.m; path = Analytics/Classes/Integrations/SEGGroupPayload.m; sourceTree = "<group>"; };
+		BF06C3113CD98F25E4E3B0E64788E313 /* ISPPinnedNSURLConnectionDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ISPPinnedNSURLConnectionDelegate.m; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLConnectionDelegate.m; sourceTree = "<group>"; };
+		BFA016998F2899C2ADC09D5C1BF087CA /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
+		BFE4DA883DD1F9251DB34826775FB995 /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
+		C0203358C30C7D50BA9DDD504A84C3C8 /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
+		C0F302DA1F3BDDA8AFA387162D474668 /* SEGGroupPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGGroupPayload.h; path = Analytics/Classes/Integrations/SEGGroupPayload.h; sourceTree = "<group>"; };
 		C41A61F5B5BE09932B32C0A22ED47F68 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		C5F5955C56ED8C3CE768F62CF97D315C /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
-		C6A20B0188A3498C1BF941FFD2D6C1F4 /* ComodoCaLimitedRsaCertificationAuthority.der */ = {isa = PBXFileReference; includeInIndex = 1; name = ComodoCaLimitedRsaCertificationAuthority.der; path = Amplitude/ComodoCaLimitedRsaCertificationAuthority.der; sourceTree = "<group>"; };
-		C7864D2D58FF8CFBCE767B659A43CE52 /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
-		C7B2F4923D3F9DBBD915235BFF34A351 /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
-		C84412F83A5F148364D1E67B847D77CD /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
-		C9AC24784C30C3431EB1F8DDBC633F96 /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
-		CA7A24A8996C22462C2EDC4F01035228 /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
-		CB47AC06F9FF53943AD1E3614667E18E /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
-		CB68BD5E52A21270EFAAEE385E631CBA /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
-		CC08FDF6CA2199E0B1B0AE6564F70491 /* AMPURLConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPURLConnection.h; path = Amplitude/AMPURLConnection.h; sourceTree = "<group>"; };
-		CCA20B01CB3FFD49FBB770361088479A /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
-		CD3686A66CFB372FE347714D02A6D985 /* SEGPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGPayload.h; path = Analytics/Classes/Integrations/SEGPayload.h; sourceTree = "<group>"; };
-		D01ACB8983BBEBD8B787B3E66808DBBA /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
-		D089DD0061232FD80BCC676DEF86C5DB /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
-		D09826FF261A1E917BC82225E3F90C1B /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
-		D0B44C497833D4F0381DD02B45274468 /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
-		D0C4D91D8EEAD9CFADD8FCD3FCEF72A0 /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
-		D1DD8BF06883C96A75A1C226FAFA4C0A /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
-		D3AF662787AD08B455F0CC8A8A8CBF74 /* SEGPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGPayload.m; path = Analytics/Classes/Integrations/SEGPayload.m; sourceTree = "<group>"; };
-		D43D1D65266064FC1F3AB45EA899A44C /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
+		C474F4E3801C28FC7870D5C5D5C53166 /* SEGPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGPayload.h; path = Analytics/Classes/Integrations/SEGPayload.h; sourceTree = "<group>"; };
+		C5CDBDAFA3F4C8492411C3243EBFE7F2 /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
+		C6F585211CBDFD0BAECA45BB97D78A9D /* SEGSegmentIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegrationFactory.h; path = Analytics/Classes/Internal/SEGSegmentIntegrationFactory.h; sourceTree = "<group>"; };
+		C78DD6ECAC16219186C8694F3636ABE4 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
+		CB1089573C5D78D1D9F4065D16C8A254 /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
+		CD3946468521A5C03872FAED0AEB8B9A /* AMPDatabaseHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPDatabaseHelper.h; path = Amplitude/AMPDatabaseHelper.h; sourceTree = "<group>"; };
+		CDC505070B4250C297A5D7CF0DFCF9D7 /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
+		CEA82773650054498F0853656DCB9F78 /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
+		CFC8F91A2C864DB1EEF81E8287DEAAC3 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
+		D3D581E7B5A8E932BC6576FD0D013405 /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
+		D4804B196F00926BF7039E981AFF5201 /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
 		D483CEA65379BCA1BD171736A01004E9 /* SEGAmplitudeIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SEGAmplitudeIntegrationFactory.m; sourceTree = "<group>"; };
-		D5434306671DC296FCAB57307AF691A0 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
-		D64E3CB905590A5320E158F852FE05DB /* AMPLocationManagerDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPLocationManagerDelegate.h; path = Amplitude/AMPLocationManagerDelegate.h; sourceTree = "<group>"; };
-		D858488EB708C48EDA7ACE8FDC3CF949 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
-		D948C2A998FA9EFDA262DB873785DBEE /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
-		D9D85E56DACBB8185EA48758696A1690 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
-		DA70104D1AE381BEE73119B3654906F3 /* SEGSerializableValue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSerializableValue.h; path = Analytics/Classes/SEGSerializableValue.h; sourceTree = "<group>"; };
-		DADA13181873EC8F573DBD56945C88C4 /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
-		DCAA5F30C6F6543404727957A092A302 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
-		DCBCFC6EA657BC510C43DCE96BCD865F /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
-		DDA1F4D5BFD0477D1595C6327A471002 /* Amplitude-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Amplitude-iOS-dummy.m"; sourceTree = "<group>"; };
-		DF7DA39664909AF7E002ABE7918BCB0A /* SEGAES256Crypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAES256Crypto.h; path = Analytics/Classes/Crypto/SEGAES256Crypto.h; sourceTree = "<group>"; };
-		E07065758CC70FC2D885E41D8CC58125 /* SEGGroupPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGGroupPayload.h; path = Analytics/Classes/Integrations/SEGGroupPayload.h; sourceTree = "<group>"; };
-		E085D8F2B03CBE9CFFB0547E2C7FBDC7 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
+		D83616CB59DD1D75C0B7EEC817D99351 /* AMPIdentify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPIdentify.m; path = Amplitude/AMPIdentify.m; sourceTree = "<group>"; };
+		D9155026603089F4E514ADBBD5CDED30 /* SEGUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGUtils.m; path = Analytics/Classes/Internal/SEGUtils.m; sourceTree = "<group>"; };
+		DB257F00932050CF6FA5A533F9FEDD29 /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
+		DC93F8AE31A351A4D7160035E38A8E66 /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
+		DC9D4EFC036270EB591EF8238A462E0A /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
+		DF189E35266595DAB93B664E6198608C /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
+		DF8CD68C7CD09BA1BEC89141745B6966 /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
+		DF91A61519ACFB2C467422128D789F5E /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
+		E04665222996CFE32A931411D9A15E04 /* ISPCertificatePinning.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISPCertificatePinning.h; path = Amplitude/SSLCertificatePinning/ISPCertificatePinning.h; sourceTree = "<group>"; };
+		E1E9F45CA27D7D108F1A2715C25141A0 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
 		E30B96E83CE3D7D34DBFBF74300A0E58 /* Pods-Segment-Amplitude_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Segment-Amplitude_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		E572DB4276FD57089332A893BF45EB3C /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
-		E7BF3C01FAFCDE8A77508E8955E94738 /* SEGScreenPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGScreenPayload.h; path = Analytics/Classes/Integrations/SEGScreenPayload.h; sourceTree = "<group>"; };
-		E9CD8C83F50CA68BF5E95B196463D734 /* ComodoRsaCA.der */ = {isa = PBXFileReference; includeInIndex = 1; name = ComodoRsaCA.der; path = Amplitude/ComodoRsaCA.der; sourceTree = "<group>"; };
-		EA46FED4F2CB942CAE0D2962694E986A /* SEGSegmentIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegrationFactory.m; path = Analytics/Classes/Internal/SEGSegmentIntegrationFactory.m; sourceTree = "<group>"; };
-		EB6C84AC521E8B87CF188A2E0FB9BB8B /* AMPARCMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPARCMacros.h; path = Amplitude/AMPARCMacros.h; sourceTree = "<group>"; };
-		EC03DAFBFF72340793C1DDE3324E5925 /* SEGSegmentIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegrationFactory.h; path = Analytics/Classes/Internal/SEGSegmentIntegrationFactory.h; sourceTree = "<group>"; };
-		EC4CA971AB0200877A46A94826217D3F /* SEGUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGUtils.h; path = Analytics/Classes/Internal/SEGUtils.h; sourceTree = "<group>"; };
-		ED63303A6EAE693A30D3206225EFC939 /* SEGAnalyticsConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsConfiguration.m; path = Analytics/Classes/SEGAnalyticsConfiguration.m; sourceTree = "<group>"; };
-		F06571EBB8704E1E305134C325265164 /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
-		F15FE16955131A608C7414E717E0CFA0 /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
+		E3B5801A720209F5877FCA6A2481DF02 /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
+		E5DFFE614FBB489DAA5FE0EBA241F657 /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
+		E631382627362D859C81669F86AEBF1A /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
+		E66C54443AF525E30AE725EDBC4EFA3B /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
+		E7A76C9D6428C008893C71A6857516C7 /* SEGSegmentIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegrationFactory.m; path = Analytics/Classes/Internal/SEGSegmentIntegrationFactory.m; sourceTree = "<group>"; };
+		E81342EE4802355DA2D643EFC3C55FFB /* SEGIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationFactory.h; path = Analytics/Classes/Integrations/SEGIntegrationFactory.h; sourceTree = "<group>"; };
+		E82064F20937870458AAA758DA8DE996 /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
+		E855BEE6E423D01699699C84B373AB8A /* ISPPinnedNSURLConnectionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISPPinnedNSURLConnectionDelegate.h; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLConnectionDelegate.h; sourceTree = "<group>"; };
+		E9290B3E2DE1E9A069BA003CF65E4210 /* AMPUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPUtils.h; path = Amplitude/AMPUtils.h; sourceTree = "<group>"; };
+		EBFAD0477BEBB7D20FBA513911C18760 /* SEGReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGReachability.m; path = Analytics/Classes/Internal/SEGReachability.m; sourceTree = "<group>"; };
+		EC70FF0DBAD37273B6700C66A330F9A7 /* SEGReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGReachability.h; path = Analytics/Classes/Internal/SEGReachability.h; sourceTree = "<group>"; };
+		ECC3EE731EA5025CC6FC25C8726DE077 /* AMPRevenue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPRevenue.h; path = Amplitude/AMPRevenue.h; sourceTree = "<group>"; };
+		ED58F86EDCF2935AF1DA45DAC1FD3EFF /* SEGAnalyticsConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsConfiguration.h; path = Analytics/Classes/SEGAnalyticsConfiguration.h; sourceTree = "<group>"; };
+		EF5FCF7F455CD87F6C1A598CEAD733F0 /* SEGIntegrationsManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationsManager.h; path = Analytics/Classes/Integrations/SEGIntegrationsManager.h; sourceTree = "<group>"; };
+		F1510DBB1658AD2CF375BD17B3C9DA7D /* AMPIdentify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AMPIdentify.h; path = Amplitude/AMPIdentify.h; sourceTree = "<group>"; };
 		F2BAF58B915636CE3888C9AF74781650 /* libAnalytics.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libAnalytics.a; path = libAnalytics.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		F4E3B3080AA80EBFA42AA8A004E583C0 /* SEGFileStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGFileStorage.h; path = Analytics/Classes/Internal/SEGFileStorage.h; sourceTree = "<group>"; };
+		F3FE21B9039733E71B93E512AEC4A6ED /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
 		F52BA2357D444E443A74106ECD6307D2 /* Pods-Segment-Amplitude_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-Amplitude_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		F639DD9CA0941BB5736CD8E0EEB30952 /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
+		F5C292C4386D7C4728ED9E5A1E1D2511 /* SEGPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGPayload.m; path = Analytics/Classes/Integrations/SEGPayload.m; sourceTree = "<group>"; };
+		F64744364C0608515F7235BD4B18B063 /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
 		F6B4109239CD4F62F20F110F2AA73616 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libSpecta.a; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		F8774BD83503B7DABCBA54451223F381 /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
-		F887E9650231B6D0DA2C4B5C432BB449 /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
-		F901DD6B56C5ACD0460F3D6D30DB4502 /* Analytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Analytics-dummy.m"; sourceTree = "<group>"; };
-		FA2A3892483B8B8DE3BCD494B2CBBC5B /* AMPUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AMPUtils.m; path = Amplitude/AMPUtils.m; sourceTree = "<group>"; };
-		FA88632FC097D02CD0C50B14D40A0D07 /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
-		FBDD472A28BA7C50D992962F37ED54DF /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
-		FC6581939835E2791A4600EF8E2B13F7 /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
-		FE6F6EF49D7D0A74E07845A3660316FE /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
+		F71F84F607CE2613616DC5D0EA723E50 /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
+		F8A502F471FC784AB82CB1796D84D68D /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
+		F9CC1D859465CCE151D6630380145955 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
+		FB6B4F13A71EC73F837F2B7DD3C26DCE /* SEGFileStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGFileStorage.h; path = Analytics/Classes/Internal/SEGFileStorage.h; sourceTree = "<group>"; };
+		FBF1D69694C345057255DE4027C05181 /* SEGAliasPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAliasPayload.h; path = Analytics/Classes/Integrations/SEGAliasPayload.h; sourceTree = "<group>"; };
+		FC333AD1B7627E96142DCFDE17A30B62 /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
+		FC6AB127252F815D4765407629CAEE79 /* SEGSegmentIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegration.h; path = Analytics/Classes/Internal/SEGSegmentIntegration.h; sourceTree = "<group>"; };
+		FD7631E18F4EA5CECA01ABE0629136B3 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
+		FE454C0929DACA9BAD6BDAF8E6523084 /* ISPPinnedNSURLSessionDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ISPPinnedNSURLSessionDelegate.m; path = Amplitude/SSLCertificatePinning/ISPPinnedNSURLSessionDelegate.m; sourceTree = "<group>"; };
+		FF2EE7D7AF3B77748F0B1CAB1E80A9C4 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
+		FFB5DE36C4DD3626244B57785F82D801 /* SEGFileStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGFileStorage.m; path = Analytics/Classes/Internal/SEGFileStorage.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -502,11 +506,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		29F309B10465F223E9521685284E9F49 /* Frameworks */ = {
+		445323DE568869B661B482F88F8F8CB3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F93CE767C6CAEF68DFFBAA8989F40FB7 /* Foundation.framework in Frameworks */,
+				8104810999ADB5B9268551391F536E97 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,23 +550,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		067A25FE109B07A450B8C5C2A05AF300 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				4E6A73E02028A9E00279952D23CB9FED /* Expecta.xcconfig */,
+				2AC161BCA7674BCC44159C26CDBFE5E1 /* Expecta-dummy.m */,
+				5F11B1E66913BA1E16E10B0AC7F6A094 /* Expecta-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Expecta";
+			sourceTree = "<group>";
+		};
 		122DA2E5084A4393C29BE363C764795C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				801C6F6185390E842A987E8C6D53C55F /* iOS */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		1527471E28CCEB1F38D16F576EA5E097 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				B22DF54B7066123934BD64EC79F0E751 /* Analytics.xcconfig */,
-				F901DD6B56C5ACD0460F3D6D30DB4502 /* Analytics-dummy.m */,
-				69642322049325A5D69C9757E58D4960 /* Analytics-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Analytics";
 			sourceTree = "<group>";
 		};
 		1C9E8B450C4351A011B5687387E66982 /* Pods-Segment-Amplitude_Example */ = {
@@ -580,177 +584,166 @@
 			path = "Target Support Files/Pods-Segment-Amplitude_Example";
 			sourceTree = "<group>";
 		};
-		20A41EB11BD258ADB250E3C07FFF009B /* Analytics */ = {
+		1FE6F78864929E73E554CDEEA8D84322 /* Expecta */ = {
 			isa = PBXGroup;
 			children = (
-				3C8FCF193AEFBCCA25FFF87324CF62DE /* NSData+SEGGZIP.h */,
-				BA03B2E04B17DB398ADD5C7688CDBF82 /* NSData+SEGGZIP.m */,
-				DF7DA39664909AF7E002ABE7918BCB0A /* SEGAES256Crypto.h */,
-				057CE4BDD50D52C36831D6C4432CE58E /* SEGAES256Crypto.m */,
-				1C83BEB5247FF766E2A486068177A78A /* SEGAliasPayload.h */,
-				95CDF764B3AB9BEF612C6FE52DBEBBB2 /* SEGAliasPayload.m */,
-				BABCB9B2DC83996225AA8ABCE5BA6F5A /* SEGAnalytics.h */,
-				1C4C4D307678E2EB15890867D6B13A15 /* SEGAnalytics.m */,
-				535E6FE9F09EE7A34A7AA0B24CFA224C /* SEGAnalyticsConfiguration.h */,
-				ED63303A6EAE693A30D3206225EFC939 /* SEGAnalyticsConfiguration.m */,
-				7898DBA0A41336906E5CC5DD30A0CA7F /* SEGAnalyticsUtils.h */,
-				852F41FE0DEC18E699B7C269B3B087A2 /* SEGAnalyticsUtils.m */,
-				2016D9062A4D08C4EFDB187517DDD55A /* SEGContext.h */,
-				9C7ECE7F16091058BFF65B4E6DF256DF /* SEGContext.m */,
-				564D7B2B174AB666A303BC00345E11F6 /* SEGCrypto.h */,
-				F4E3B3080AA80EBFA42AA8A004E583C0 /* SEGFileStorage.h */,
-				887A060C2E187B4063B3DCBFEF4447E0 /* SEGFileStorage.m */,
-				E07065758CC70FC2D885E41D8CC58125 /* SEGGroupPayload.h */,
-				0245D4F7384198D81E95FB65F210D6D5 /* SEGGroupPayload.m */,
-				9D791A5995215B502A193FDC7473619F /* SEGHTTPClient.h */,
-				13C3D2412FF4B6BCF60D61F4C7B85E81 /* SEGHTTPClient.m */,
-				81E8E1ED0B06B95947FF1950C097937F /* SEGIdentifyPayload.h */,
-				42A11F8A655956BD0ECBF23D916DF693 /* SEGIdentifyPayload.m */,
-				AE9536CC20968448AEB856438F0FE8E5 /* SEGIntegration.h */,
-				775B24803BDB4696043B72B523099331 /* SEGIntegrationFactory.h */,
-				92E7E223FB84E9BB010C15000FEEA0E2 /* SEGIntegrationsManager.h */,
-				211C04DC2D1B25A68A8E22F74EE9A1B5 /* SEGIntegrationsManager.m */,
-				35CDA8795091411CBBAE195C039E8222 /* SEGMiddleware.h */,
-				9A2418FDACE26FD5D9FB10B6DD6354AD /* SEGMiddleware.m */,
-				CD3686A66CFB372FE347714D02A6D985 /* SEGPayload.h */,
-				D3AF662787AD08B455F0CC8A8A8CBF74 /* SEGPayload.m */,
-				3C14F0FB1BD4B13E096EC7F35FC74441 /* SEGReachability.h */,
-				391E38B40014B3C5AE2649E5BB162657 /* SEGReachability.m */,
-				E7BF3C01FAFCDE8A77508E8955E94738 /* SEGScreenPayload.h */,
-				A50B67FF1D6096FC9872483DC8E2EA0D /* SEGScreenPayload.m */,
-				3F8A2CB61EA957F84C62D74D090E3A2F /* SEGSegmentIntegration.h */,
-				1AE19A94029A969428AC1B9FCF48BA24 /* SEGSegmentIntegration.m */,
-				EC03DAFBFF72340793C1DDE3324E5925 /* SEGSegmentIntegrationFactory.h */,
-				EA46FED4F2CB942CAE0D2962694E986A /* SEGSegmentIntegrationFactory.m */,
-				DA70104D1AE381BEE73119B3654906F3 /* SEGSerializableValue.h */,
-				0F895F4449950843D39F57D4C3A020B0 /* SEGStorage.h */,
-				9791B1C154ABB159E483EC759C5D7A0D /* SEGStoreKitTracker.h */,
-				0CF93D12AF0BFAE9EC32A912522FA036 /* SEGStoreKitTracker.m */,
-				30059F086F05B2FA99DD533F5FCD0A1E /* SEGTrackPayload.h */,
-				12F313B56D2FCFD91427AD8EB2C2E916 /* SEGTrackPayload.m */,
-				22D9B27E3593B4FE7E6F1E31FDF5BF31 /* SEGUserDefaultsStorage.h */,
-				7E4D103CAE09CC3696359FC39E1DC405 /* SEGUserDefaultsStorage.m */,
-				EC4CA971AB0200877A46A94826217D3F /* SEGUtils.h */,
-				0B0135A3C0749A259EA98A8504132376 /* SEGUtils.m */,
-				9DE4B1D248315C223B3A581F8E079024 /* UIViewController+SEGScreen.h */,
-				41FD8F7ECD70A1B0DEB7A663FD6AEE37 /* UIViewController+SEGScreen.m */,
-				1527471E28CCEB1F38D16F576EA5E097 /* Support Files */,
-			);
-			name = Analytics;
-			path = Analytics;
-			sourceTree = "<group>";
-		};
-		27945C278F958A8CA533182161013E90 /* Expecta */ = {
-			isa = PBXGroup;
-			children = (
-				C5F5955C56ED8C3CE768F62CF97D315C /* EXPBlockDefinedMatcher.h */,
-				F06571EBB8704E1E305134C325265164 /* EXPBlockDefinedMatcher.m */,
-				54D8915248E23900D0FE5028630DDF41 /* EXPDefines.h */,
-				C06B31F31766322C502CAB6C6C2F92D8 /* EXPDoubleTuple.h */,
-				8D8E7A6E4840BA29E0A4149F853864C1 /* EXPDoubleTuple.m */,
-				062F1C5B07E68407382E548A171FEF0E /* Expecta.h */,
-				23E622EC871443CB64E795D87CC3EB8F /* ExpectaObject.h */,
-				8B3265087784501F7BE4519246D7587E /* ExpectaObject.m */,
-				4AFBF8397123195FC2207F60E5EC35EB /* ExpectaSupport.h */,
-				FA88632FC097D02CD0C50B14D40A0D07 /* ExpectaSupport.m */,
-				2569283733FA66D4BCD8B9CE107C1ED1 /* EXPExpect.h */,
-				42C40EB2DCFD06A0C6F301FBD3779C67 /* EXPExpect.m */,
-				5DB325529B7A3863CD4392BBEDB2110B /* EXPFloatTuple.h */,
-				B910263EE03D2C9834FFBCC0C953AB8E /* EXPFloatTuple.m */,
-				5B59B4359A00BAA62A4056EF8E7A2923 /* EXPMatcher.h */,
-				683CAC4BA6B707B65F2326EAFFB2CDCA /* EXPMatcherHelpers.h */,
-				23353B63CC7BA6791AD8A80B65C560F5 /* EXPMatcherHelpers.m */,
-				D5434306671DC296FCAB57307AF691A0 /* EXPMatchers.h */,
-				90DE6A11107EDD0F3236A7191A03ACB2 /* EXPMatchers+beCloseTo.h */,
-				C9AC24784C30C3431EB1F8DDBC633F96 /* EXPMatchers+beCloseTo.m */,
-				9A1ED211388C33C2B02FB3B847D5FEEC /* EXPMatchers+beFalsy.h */,
-				349E06C875B231081A714DC34B9E8F70 /* EXPMatchers+beFalsy.m */,
-				04C997D20AAE150754DC2D008D97C002 /* EXPMatchers+beginWith.h */,
-				818103592EEE2F0699560E22A2283FA9 /* EXPMatchers+beginWith.m */,
-				973EF3AA585F3267168AF659D90CDB74 /* EXPMatchers+beGreaterThan.h */,
-				6CAFB6BACDAF3A80C523ABAFCBF7DB3B /* EXPMatchers+beGreaterThan.m */,
-				AC710D09972E764BC5D2F36D869DABA3 /* EXPMatchers+beGreaterThanOrEqualTo.h */,
-				68103AF3D0F9D0B3F8A870030B2B7622 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
-				34981AF8FD0AA321CE63B26FF54AFBF8 /* EXPMatchers+beIdenticalTo.h */,
-				9BC3C426DCD8089601C1B6528A19AF8A /* EXPMatchers+beIdenticalTo.m */,
-				B89E639E443D6A119B1354ECFCF797F3 /* EXPMatchers+beInstanceOf.h */,
-				244ACD2F7A8506674928052A373C222A /* EXPMatchers+beInstanceOf.m */,
-				E572DB4276FD57089332A893BF45EB3C /* EXPMatchers+beInTheRangeOf.h */,
-				04D7611B749F0892496DBCA0A48ACF55 /* EXPMatchers+beInTheRangeOf.m */,
-				D948C2A998FA9EFDA262DB873785DBEE /* EXPMatchers+beKindOf.h */,
-				BF8FF5C73BB79B423731E0905C8AC6CB /* EXPMatchers+beKindOf.m */,
-				C7864D2D58FF8CFBCE767B659A43CE52 /* EXPMatchers+beLessThan.h */,
-				C84412F83A5F148364D1E67B847D77CD /* EXPMatchers+beLessThan.m */,
-				7AA96730930522599FDCF58FD5822C3C /* EXPMatchers+beLessThanOrEqualTo.h */,
-				01480A7D9CBCBE893F37EEF86A8D104D /* EXPMatchers+beLessThanOrEqualTo.m */,
-				9CAC9B15CF6343964FE25817C5243620 /* EXPMatchers+beNil.h */,
-				A265ABE8989F2FFF05C1A0CFC8D71945 /* EXPMatchers+beNil.m */,
-				D858488EB708C48EDA7ACE8FDC3CF949 /* EXPMatchers+beSubclassOf.h */,
-				DCBCFC6EA657BC510C43DCE96BCD865F /* EXPMatchers+beSubclassOf.m */,
-				9BD36129947FA0AA12F7D4F8EB940E56 /* EXPMatchers+beSupersetOf.h */,
-				FC6581939835E2791A4600EF8E2B13F7 /* EXPMatchers+beSupersetOf.m */,
-				6CB44D917789B23A1069A81835C8D3A8 /* EXPMatchers+beTruthy.h */,
-				E085D8F2B03CBE9CFFB0547E2C7FBDC7 /* EXPMatchers+beTruthy.m */,
-				CB47AC06F9FF53943AD1E3614667E18E /* EXPMatchers+conformTo.h */,
-				D089DD0061232FD80BCC676DEF86C5DB /* EXPMatchers+conformTo.m */,
-				62BFD73EE1987F0FECC76F506D9891D4 /* EXPMatchers+contain.h */,
-				2925DD16EB69EBCEE111DB2C2BA2CE81 /* EXPMatchers+contain.m */,
-				81D5FADF1DDB8237256230366055DE7B /* EXPMatchers+endWith.h */,
-				54F461E9B166348306D21A44B4ADAFB4 /* EXPMatchers+endWith.m */,
-				C3F06A32ADD89B7686A0D540F7E44AF4 /* EXPMatchers+equal.h */,
-				CCA20B01CB3FFD49FBB770361088479A /* EXPMatchers+equal.m */,
-				F887E9650231B6D0DA2C4B5C432BB449 /* EXPMatchers+haveCountOf.h */,
-				029E661288F5C15F610D9EF753C0522B /* EXPMatchers+haveCountOf.m */,
-				D01ACB8983BBEBD8B787B3E66808DBBA /* EXPMatchers+match.h */,
-				5ABFC2270C607240D03045B116D23D99 /* EXPMatchers+match.m */,
-				D9D85E56DACBB8185EA48758696A1690 /* EXPMatchers+postNotification.h */,
-				0DADC0B7BA89EEC028DDFED11BBAB9DA /* EXPMatchers+postNotification.m */,
-				D43D1D65266064FC1F3AB45EA899A44C /* EXPMatchers+raise.h */,
-				CB68BD5E52A21270EFAAEE385E631CBA /* EXPMatchers+raise.m */,
-				826EB24E197AEE07B0F1A40AF42E9E24 /* EXPMatchers+raiseWithReason.h */,
-				DADA13181873EC8F573DBD56945C88C4 /* EXPMatchers+raiseWithReason.m */,
-				CA7A24A8996C22462C2EDC4F01035228 /* EXPMatchers+respondTo.h */,
-				1827C80EB52169F66AADCF22D57C0F01 /* EXPMatchers+respondTo.m */,
-				DCAA5F30C6F6543404727957A092A302 /* EXPUnsupportedObject.h */,
-				7E597D8EFC41E4B3BC59184AFA88C1EF /* EXPUnsupportedObject.m */,
-				B84AFD134B3A2F20C256F4CC4DCF5EDD /* NSObject+Expecta.h */,
-				D0B44C497833D4F0381DD02B45274468 /* NSValue+Expecta.h */,
-				F639DD9CA0941BB5736CD8E0EEB30952 /* NSValue+Expecta.m */,
-				A8A70390E6AF9213F8FE7E544E384405 /* Support Files */,
+				904651D94A1EC833EB0895379DF77C54 /* EXPBlockDefinedMatcher.h */,
+				88F6E85857DE7F4AD479E44321A6C355 /* EXPBlockDefinedMatcher.m */,
+				7331510219931D7EB298D2DB14D54CC8 /* EXPDefines.h */,
+				C0203358C30C7D50BA9DDD504A84C3C8 /* EXPDoubleTuple.h */,
+				B75945B18D32221F79504A270FCB9E92 /* EXPDoubleTuple.m */,
+				4455E03C82E46FE5D20A30630A3ADD46 /* Expecta.h */,
+				5A6CA514EAEB20514C511907E8917947 /* ExpectaObject.h */,
+				E3B5801A720209F5877FCA6A2481DF02 /* ExpectaObject.m */,
+				4A2504FB7A69B6D51A64C2D15DFE4FDD /* ExpectaSupport.h */,
+				9F871E6E1D6517F0708558BED3F610B8 /* ExpectaSupport.m */,
+				697A8911084F828C89B4829E1BEF6A30 /* EXPExpect.h */,
+				62CAEACD6EDC65D6C2E189E7FFBACE3F /* EXPExpect.m */,
+				13B75B9A32FE7161CF277BBE479A07DF /* EXPFloatTuple.h */,
+				447C54C123E313B6D12066A7C9D1BE60 /* EXPFloatTuple.m */,
+				6E54D5395053660ED0C4CCD8EDBCE2CD /* EXPMatcher.h */,
+				516FBEED0363BDC7AE882FD756AC663C /* EXPMatcherHelpers.h */,
+				DF189E35266595DAB93B664E6198608C /* EXPMatcherHelpers.m */,
+				F9CC1D859465CCE151D6630380145955 /* EXPMatchers.h */,
+				037D39CEA5DC274C66042BFEA46945FD /* EXPMatchers+beCloseTo.h */,
+				07BD7C1EC40068C97F0FE12085EEE12A /* EXPMatchers+beCloseTo.m */,
+				3068851374CC58D083398FDC1F834B05 /* EXPMatchers+beFalsy.h */,
+				4142BE023130309558EF01A65BA559C0 /* EXPMatchers+beFalsy.m */,
+				91B36DC084E95D0276C05B3696031C48 /* EXPMatchers+beginWith.h */,
+				E631382627362D859C81669F86AEBF1A /* EXPMatchers+beginWith.m */,
+				541F0E672A7801C26E964E01B514852F /* EXPMatchers+beGreaterThan.h */,
+				9E93604C6325CF2806F5AFAF2D135214 /* EXPMatchers+beGreaterThan.m */,
+				CB1089573C5D78D1D9F4065D16C8A254 /* EXPMatchers+beGreaterThanOrEqualTo.h */,
+				F8A502F471FC784AB82CB1796D84D68D /* EXPMatchers+beGreaterThanOrEqualTo.m */,
+				02FB07BABF1E9304C556734FD1D614B1 /* EXPMatchers+beIdenticalTo.h */,
+				890B4CD6376ABA26467B5F1D9F83C013 /* EXPMatchers+beIdenticalTo.m */,
+				055D7680BB2A0FAFA5856B6B2A784942 /* EXPMatchers+beInstanceOf.h */,
+				CEA82773650054498F0853656DCB9F78 /* EXPMatchers+beInstanceOf.m */,
+				B95634D2C2A67A4044B32F32B6F35BC8 /* EXPMatchers+beInTheRangeOf.h */,
+				E5DFFE614FBB489DAA5FE0EBA241F657 /* EXPMatchers+beInTheRangeOf.m */,
+				B339E4D939EF4F6434767CF492722E7A /* EXPMatchers+beKindOf.h */,
+				98673472A9C5E362EDCAC00FD68E264E /* EXPMatchers+beKindOf.m */,
+				00DC66922B064EB144FD148FDB38C6EF /* EXPMatchers+beLessThan.h */,
+				486E670BE7029ECAE44C8FB8B3422DD6 /* EXPMatchers+beLessThan.m */,
+				DC9D4EFC036270EB591EF8238A462E0A /* EXPMatchers+beLessThanOrEqualTo.h */,
+				BFE4DA883DD1F9251DB34826775FB995 /* EXPMatchers+beLessThanOrEqualTo.m */,
+				A538DE0A412504C66899D007094F833D /* EXPMatchers+beNil.h */,
+				C5CDBDAFA3F4C8492411C3243EBFE7F2 /* EXPMatchers+beNil.m */,
+				E82064F20937870458AAA758DA8DE996 /* EXPMatchers+beSubclassOf.h */,
+				5C311E99953DBE59C3D36FF8313E7DD6 /* EXPMatchers+beSubclassOf.m */,
+				9EB8345DC7265292F389D3485E3ACDAA /* EXPMatchers+beSupersetOf.h */,
+				F64744364C0608515F7235BD4B18B063 /* EXPMatchers+beSupersetOf.m */,
+				4476A3BC8005F9AA025A4C79112746FA /* EXPMatchers+beTruthy.h */,
+				CFC8F91A2C864DB1EEF81E8287DEAAC3 /* EXPMatchers+beTruthy.m */,
+				79F45ECA8987D0089E95769120E5A740 /* EXPMatchers+conformTo.h */,
+				83A0B0BFEC9A20036CF5D2DA955A9416 /* EXPMatchers+conformTo.m */,
+				5821508B39F208764DE9C7C8EA13179A /* EXPMatchers+contain.h */,
+				7F0DB86E7469DC751133C1052D05B2C0 /* EXPMatchers+contain.m */,
+				8CA660ECD5289B2E9F913D6BFB187FA7 /* EXPMatchers+endWith.h */,
+				FD7631E18F4EA5CECA01ABE0629136B3 /* EXPMatchers+endWith.m */,
+				C78DD6ECAC16219186C8694F3636ABE4 /* EXPMatchers+equal.h */,
+				6A6F256393F6A7EFE7ED6239F9F6ED46 /* EXPMatchers+equal.m */,
+				E66C54443AF525E30AE725EDBC4EFA3B /* EXPMatchers+haveCountOf.h */,
+				A00AB0401B5B51D3D6FE7C3E1C66B8BE /* EXPMatchers+haveCountOf.m */,
+				A1CCB973F606819CC7C2A7DB16FF383B /* EXPMatchers+match.h */,
+				DB257F00932050CF6FA5A533F9FEDD29 /* EXPMatchers+match.m */,
+				6388B8E2B5D07C3F842D48F79BA6F4F3 /* EXPMatchers+postNotification.h */,
+				045247DCDD9A3BE74448A6A60A7B3C1C /* EXPMatchers+postNotification.m */,
+				F71F84F607CE2613616DC5D0EA723E50 /* EXPMatchers+raise.h */,
+				A6A39483C7584E1F98C518913C94CECF /* EXPMatchers+raise.m */,
+				4B3B423BA8A318512E8E54ADE4314BB5 /* EXPMatchers+raiseWithReason.h */,
+				BFA016998F2899C2ADC09D5C1BF087CA /* EXPMatchers+raiseWithReason.m */,
+				6073F569662785196B3A57674CCABD27 /* EXPMatchers+respondTo.h */,
+				CDC505070B4250C297A5D7CF0DFCF9D7 /* EXPMatchers+respondTo.m */,
+				FC333AD1B7627E96142DCFDE17A30B62 /* EXPUnsupportedObject.h */,
+				9CB3AA995650C5069C380C7B2AA9C3EA /* EXPUnsupportedObject.m */,
+				AA2240B5CBAA31E45426F2615A5F65A7 /* NSObject+Expecta.h */,
+				85C54A5B9CBFC10D616BB614A3809648 /* NSValue+Expecta.h */,
+				87300EAB4B8D40E44664C39237A572A4 /* NSValue+Expecta.m */,
+				067A25FE109B07A450B8C5C2A05AF300 /* Support Files */,
 			);
 			name = Expecta;
 			path = Expecta;
 			sourceTree = "<group>";
 		};
-		4386EDA6C0B2B49527FD18FE6BD6A6F4 /* Specta */ = {
+		51A58A99B3BB4B46AED26E6A33D0CB5B /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				A80CE8B4914733F05FA29D5E6EC1A075 /* Specta.h */,
-				733E054797F042C3899A8835485E84E9 /* SpectaDSL.h */,
-				670C6376CF3221E88A973FA56828596A /* SpectaDSL.m */,
-				D1DD8BF06883C96A75A1C226FAFA4C0A /* SpectaTypes.h */,
-				052708A7CCE881EBBE100FC5D2A9576B /* SpectaUtility.h */,
-				2DA2CE5A5C54DC8DE8843ECC48238783 /* SpectaUtility.m */,
-				074A7F72471D17B9B39B2FD5A91BC047 /* SPTCallSite.h */,
-				426EC199E1D780EE7F9889E140D03AF3 /* SPTCallSite.m */,
-				FE6F6EF49D7D0A74E07845A3660316FE /* SPTCompiledExample.h */,
-				4010254F0C43E3F606BCF2CF54F73DBA /* SPTCompiledExample.m */,
-				0D6688073A8B98C99AFA0DAD52F38EA4 /* SPTExample.h */,
-				319CD8F9255AB12DC3E5500AA4A7277E /* SPTExample.m */,
-				669471B098D52AED0FAF3BBB2F239C1F /* SPTExampleGroup.h */,
-				B87CB82AEE07830FD01226B42F26BEFB /* SPTExampleGroup.m */,
-				42A56A8F8C726F86F98F0CE6982607D1 /* SPTExcludeGlobalBeforeAfterEach.h */,
-				496E777ED919382F084EA1AC9327D144 /* SPTGlobalBeforeAfterEach.h */,
-				6AFD81A519442C17BD66D4CF6869208D /* SPTSharedExampleGroups.h */,
-				9C6479793D1B08323285DCF6969FBE89 /* SPTSharedExampleGroups.m */,
-				D0C4D91D8EEAD9CFADD8FCD3FCEF72A0 /* SPTSpec.h */,
-				C22B1B3B9FEBE179CC63DFB3E09852BD /* SPTSpec.m */,
-				F8774BD83503B7DABCBA54451223F381 /* SPTTestSuite.h */,
-				10550C05222935F9FC33D144292240FB /* SPTTestSuite.m */,
-				FBDD472A28BA7C50D992962F37ED54DF /* XCTest+Private.h */,
-				8CA6702B35516C5F8DB5D7827B1D3106 /* XCTestCase+Specta.h */,
-				C7B2F4923D3F9DBBD915235BFF34A351 /* XCTestCase+Specta.m */,
-				AC6BAB4F0DB51C2FD3B9C82D3978F40A /* Support Files */,
+				A5521A048F5A31ADBD0B40AF8883E83C /* api.amplitude.com.der */,
+				64B24A9D559159DBFA62E28E21D24F45 /* ComodoCaLimitedRsaCertificationAuthority.der */,
+				48AB5F7F336A88CD4CB881C8778B39B3 /* ComodoRsaCA.der */,
+				2DC86C19A8B9CA748D479F727FEC9BE1 /* ComodoRsaDomainValidationCA.der */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		5512E39B0A265EC80350FF05010405A1 /* Amplitude-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				8D4FC7ABCD2E0489967F7ED31C490964 /* AMPARCMacros.h */,
+				9F4E64D6D8430AAEB01C516D700D5267 /* AMPConstants.h */,
+				9C3EB0680BC7EB2FFE45E74E150A2A1E /* AMPConstants.m */,
+				CD3946468521A5C03872FAED0AEB8B9A /* AMPDatabaseHelper.h */,
+				400149180DD517A0DFD70107487604C8 /* AMPDatabaseHelper.m */,
+				4DAA459F1E1D952F2400377515E2C921 /* AMPDeviceInfo.h */,
+				106B4700274B0FBFE7EB79FB5A45112D /* AMPDeviceInfo.m */,
+				F1510DBB1658AD2CF375BD17B3C9DA7D /* AMPIdentify.h */,
+				D83616CB59DD1D75C0B7EEC817D99351 /* AMPIdentify.m */,
+				0C62328863DF9BD01E9270A3B882B436 /* Amplitude.h */,
+				2D922C3CFE46CE8B2BAFBC23E7BA316D /* Amplitude.m */,
+				342018E29907F78799D523D920D3EF5E /* Amplitude+SSLPinning.h */,
+				149A5419BEDCE361C45AF68F19551FA6 /* AMPLocationManagerDelegate.h */,
+				439659C5E707F12F8FF8D9377D22DC12 /* AMPLocationManagerDelegate.m */,
+				ECC3EE731EA5025CC6FC25C8726DE077 /* AMPRevenue.h */,
+				049666E8CB9D1EBE336D9FE1B8B36DA6 /* AMPRevenue.m */,
+				469035B8DA115714C2F921BA21D53A60 /* AMPURLConnection.h */,
+				94FD2853D0A0D17EBC31540ED4F0AAD9 /* AMPURLConnection.m */,
+				83AAF4FCC4701997C2327D6EC97EDF71 /* AMPURLSession.h */,
+				4965FF0C8B97FDC1BFCCEEB48A4009AF /* AMPURLSession.m */,
+				E9290B3E2DE1E9A069BA003CF65E4210 /* AMPUtils.h */,
+				366413D85AF2EAB2DA5741BB8827C64F /* AMPUtils.m */,
+				E04665222996CFE32A931411D9A15E04 /* ISPCertificatePinning.h */,
+				0BACD39777742EB692EEA6B0E2B6B8FE /* ISPCertificatePinning.m */,
+				E855BEE6E423D01699699C84B373AB8A /* ISPPinnedNSURLConnectionDelegate.h */,
+				BF06C3113CD98F25E4E3B0E64788E313 /* ISPPinnedNSURLConnectionDelegate.m */,
+				76C307D7FC8D3AA8ADC048D811E3676C /* ISPPinnedNSURLSessionDelegate.h */,
+				FE454C0929DACA9BAD6BDAF8E6523084 /* ISPPinnedNSURLSessionDelegate.m */,
+				51A58A99B3BB4B46AED26E6A33D0CB5B /* Resources */,
+				81049C64274BB6F6009F4AF5896A683E /* Support Files */,
+			);
+			name = "Amplitude-iOS";
+			path = "Amplitude-iOS";
+			sourceTree = "<group>";
+		};
+		5A0627E3B6A6C999D8BD5F255E6B2A55 /* Specta */ = {
+			isa = PBXGroup;
+			children = (
+				E1E9F45CA27D7D108F1A2715C25141A0 /* Specta.h */,
+				5DA534F4A25B3D8D7DEB7FB04D7DA2EF /* SpectaDSL.h */,
+				0F0FE2B5A0B556A439AF293EA85F7D79 /* SpectaDSL.m */,
+				3FE56EFE03C000589BBC46DC061FF713 /* SpectaTypes.h */,
+				95C6E99E732850A4A8F2B696A01C2235 /* SpectaUtility.h */,
+				62AE75FBAAE05FCA79C3157E8B0534E8 /* SpectaUtility.m */,
+				27205BEE57D0EF3AD7ACB7ECB8AC2ACB /* SPTCallSite.h */,
+				DF8CD68C7CD09BA1BEC89141745B6966 /* SPTCallSite.m */,
+				8F0062B708509828C55C300839C07908 /* SPTCompiledExample.h */,
+				B15A9E2382295010114AE017F335AEA8 /* SPTCompiledExample.m */,
+				28D7F35F2E6AF80FDEB18D7EC82B4675 /* SPTExample.h */,
+				DF91A61519ACFB2C467422128D789F5E /* SPTExample.m */,
+				D4804B196F00926BF7039E981AFF5201 /* SPTExampleGroup.h */,
+				87606149D989BB87D20275EDE8194667 /* SPTExampleGroup.m */,
+				B54549AE2FB2CA5C171A7570CC94E0DF /* SPTExcludeGlobalBeforeAfterEach.h */,
+				B3C6D35DEAA0017CFCCFE9637D2686B8 /* SPTGlobalBeforeAfterEach.h */,
+				2EAB98B9DEB4AB708653F15889D263A9 /* SPTSharedExampleGroups.h */,
+				114FF9105326AB0F3517997351EBCC69 /* SPTSharedExampleGroups.m */,
+				6B89EA57522BBD61009D4D3D326BF6BA /* SPTSpec.h */,
+				4F7E64AA595D91F517C8F14DE8C3A28F /* SPTSpec.m */,
+				B90C61E9442077359B2D916B1B0E7FEE /* SPTTestSuite.h */,
+				F3FE21B9039733E71B93E512AEC4A6ED /* SPTTestSuite.m */,
+				D3D581E7B5A8E932BC6576FD0D013405 /* XCTest+Private.h */,
+				FF2EE7D7AF3B77748F0B1CAB1E80A9C4 /* XCTestCase+Specta.h */,
+				A72B4ED9BE22367B0C80D360DE43A738 /* XCTestCase+Specta.m */,
+				CC1BD6FFC01DFAFCB0F066F6E36A999A /* Support Files */,
 			);
 			name = Specta;
 			path = Specta;
@@ -770,17 +763,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		71C76FBC2AF3E438FB8F504BE872E6E6 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				54E4323B155EE86D7930101B5D6D72CF /* Amplitude-iOS.xcconfig */,
-				DDA1F4D5BFD0477D1595C6327A471002 /* Amplitude-iOS-dummy.m */,
-				49F1C871CFAC83BA29C085AE37AB8CE1 /* Amplitude-iOS-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Amplitude-iOS";
-			sourceTree = "<group>";
-		};
 		7664986B0A48DA135E1A5F7C1191AAE0 /* Segment-Amplitude */ = {
 			isa = PBXGroup;
 			children = (
@@ -797,7 +779,7 @@
 				93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */,
 				CDF2F4D31E43B5CC30F85031ACFF6938 /* Development Pods */,
 				122DA2E5084A4393C29BE363C764795C /* Frameworks */,
-				EC846CF90EB4A062FC620740030F48E3 /* Pods */,
+				D3E8D6354B17D9469E1F953CF4C413E0 /* Pods */,
 				6527C22F55C766940A518D735A375B08 /* Products */,
 				92B85F753ECB9011D58324FDEBA3B519 /* Targets Support Files */,
 			);
@@ -811,6 +793,17 @@
 				8960D86C5295BDF7B75BBDAAE0E08F9C /* XCTest.framework */,
 			);
 			name = iOS;
+			sourceTree = "<group>";
+		};
+		81049C64274BB6F6009F4AF5896A683E /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				3898DE5D367DF8E7F5799BD2C9E7A0B5 /* Amplitude-iOS.xcconfig */,
+				1AC292D2AD17D32A41AA8F215552057E /* Amplitude-iOS-dummy.m */,
+				9AE62F76045AD19E5321C9291DE7F5A1 /* Amplitude-iOS-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Amplitude-iOS";
 			sourceTree = "<group>";
 		};
 		833048CC4A8F7A5B95AA48D53AC525F2 /* Support Files */ = {
@@ -833,62 +826,64 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		A59A1D007D219A0F982965BDAB8BCBFA /* Amplitude-iOS */ = {
+		A91F3C2D0F1148D5F2E6DAB4F9115287 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
-				EB6C84AC521E8B87CF188A2E0FB9BB8B /* AMPARCMacros.h */,
-				103DE9996136E45A545FB0CCC49CC25D /* AMPConstants.h */,
-				B399ED8120CE53B322DD036276714A7E /* AMPConstants.m */,
-				811047735893AECD2736A9A99732CB9C /* AMPDatabaseHelper.h */,
-				7D9C73F07D5ED825725897F344AD37D7 /* AMPDatabaseHelper.m */,
-				56D50CD8694ACABA962CEA56EB52E318 /* AMPDeviceInfo.h */,
-				5F699F59178DA3C46F68433B6281BC57 /* AMPDeviceInfo.m */,
-				463B99F50CCAD25F5EAA7EA8D9D72970 /* AMPIdentify.h */,
-				0E45FD63A79F835DF60DC7B07B1BD240 /* AMPIdentify.m */,
-				1D8A786B94C7E00341A80BF140AC9918 /* Amplitude.h */,
-				4D01DE19A9AF6EEE3EE27FD208E8E204 /* Amplitude.m */,
-				1F0C6DD38DA9D5638A24CF31194BDD0C /* Amplitude+SSLPinning.h */,
-				D64E3CB905590A5320E158F852FE05DB /* AMPLocationManagerDelegate.h */,
-				BBBA8ED4F916BC134AC1AFF7BDEE5082 /* AMPLocationManagerDelegate.m */,
-				5A2D7F24D04260602A709FE7950272D2 /* AMPRevenue.h */,
-				58A06AAF545D60E532B5E580D8575E4B /* AMPRevenue.m */,
-				CC08FDF6CA2199E0B1B0AE6564F70491 /* AMPURLConnection.h */,
-				BCC428E1754486F4215F62E74C6387F0 /* AMPURLConnection.m */,
-				24EA7AE3B75F4C5093B1CDE708DE87EC /* AMPUtils.h */,
-				FA2A3892483B8B8DE3BCD494B2CBBC5B /* AMPUtils.m */,
-				30ECA58326290498D458ABD7E37FF021 /* ISPCertificatePinning.h */,
-				8410116518AC02B7B7FA8E1C72DFB851 /* ISPCertificatePinning.m */,
-				A82B9E07D3CC1758AB734ED138878DCA /* ISPPinnedNSURLConnectionDelegate.h */,
-				383D4A452F00117A26C971A8B572188A /* ISPPinnedNSURLConnectionDelegate.m */,
-				407630499F85D93A69E7AF248DA6ED49 /* ISPPinnedNSURLSessionDelegate.h */,
-				4AF0B456B975B4173A82C5394B76B59D /* ISPPinnedNSURLSessionDelegate.m */,
-				D439994C6B4CDB6751C7E624E3FAB7D4 /* Resources */,
-				71C76FBC2AF3E438FB8F504BE872E6E6 /* Support Files */,
+				13482F8367E43FE70F1A3756B1E59862 /* NSData+SEGGZIP.h */,
+				8B23CB2BF8335FD971D75F9E70E11672 /* NSData+SEGGZIP.m */,
+				5023796D5F6AE51F75FFEAB2D5A63F2A /* SEGAES256Crypto.h */,
+				64E3673979A4DF8EE8AC9CAEE772F531 /* SEGAES256Crypto.m */,
+				FBF1D69694C345057255DE4027C05181 /* SEGAliasPayload.h */,
+				558FAACFCE9B9816440EEF640FD95833 /* SEGAliasPayload.m */,
+				32852763DA17CC6C9650F629D2A1A429 /* SEGAnalytics.h */,
+				B07DCAFE90418B6612216ACFA3E804EA /* SEGAnalytics.m */,
+				ED58F86EDCF2935AF1DA45DAC1FD3EFF /* SEGAnalyticsConfiguration.h */,
+				2B29D3397DD8F4BD4594A0BAA6F396B7 /* SEGAnalyticsConfiguration.m */,
+				992CA22DFA136F4FD49D8E4A176613D0 /* SEGAnalyticsUtils.h */,
+				1AFC0F9D3BE9D166BC76B017F6047DDD /* SEGAnalyticsUtils.m */,
+				530328B68CED82B0D989DB7D28979581 /* SEGContext.h */,
+				A7E26ED2242DC4C7BBE47EB62E399A38 /* SEGContext.m */,
+				768E730FF9F2CA87AC264B37D6D28F37 /* SEGCrypto.h */,
+				FB6B4F13A71EC73F837F2B7DD3C26DCE /* SEGFileStorage.h */,
+				FFB5DE36C4DD3626244B57785F82D801 /* SEGFileStorage.m */,
+				C0F302DA1F3BDDA8AFA387162D474668 /* SEGGroupPayload.h */,
+				BE80018AFD761E1C8BCCB18C903636EE /* SEGGroupPayload.m */,
+				B8E824DDC4B9F895070BE32C061E8BDF /* SEGHTTPClient.h */,
+				6A13A5BD9AEFB9B1BCA7787A71B5BDC0 /* SEGHTTPClient.m */,
+				1A3E8E355E79BDBF6AA673C82EB1488C /* SEGIdentifyPayload.h */,
+				312BC14859AA982D73CABC8C95274558 /* SEGIdentifyPayload.m */,
+				2601D11F4D446F8940EAF29716212E6E /* SEGIntegration.h */,
+				E81342EE4802355DA2D643EFC3C55FFB /* SEGIntegrationFactory.h */,
+				EF5FCF7F455CD87F6C1A598CEAD733F0 /* SEGIntegrationsManager.h */,
+				8BC97FE030D6C6FC932A65C612CF70A9 /* SEGIntegrationsManager.m */,
+				21CF6CA8D88D7E8BBFEB5D6317F6FA8F /* SEGMiddleware.h */,
+				73BB01A277F8526FE777A73707F7076A /* SEGMiddleware.m */,
+				C474F4E3801C28FC7870D5C5D5C53166 /* SEGPayload.h */,
+				F5C292C4386D7C4728ED9E5A1E1D2511 /* SEGPayload.m */,
+				EC70FF0DBAD37273B6700C66A330F9A7 /* SEGReachability.h */,
+				EBFAD0477BEBB7D20FBA513911C18760 /* SEGReachability.m */,
+				7BB94DC2E803F41549F32ADDF85110E7 /* SEGScreenPayload.h */,
+				0B578D9F810C32D25A655729467931F0 /* SEGScreenPayload.m */,
+				FC6AB127252F815D4765407629CAEE79 /* SEGSegmentIntegration.h */,
+				AB6E092B63EA34D8E7F957F59F526445 /* SEGSegmentIntegration.m */,
+				C6F585211CBDFD0BAECA45BB97D78A9D /* SEGSegmentIntegrationFactory.h */,
+				E7A76C9D6428C008893C71A6857516C7 /* SEGSegmentIntegrationFactory.m */,
+				1FCAE1E4DC842EFCA104FC26C666733E /* SEGSerializableValue.h */,
+				B93FEF6ADEF7DB5BCDE84F78927CB62F /* SEGStorage.h */,
+				3AA117E301657060FAF000750A593A31 /* SEGStoreKitTracker.h */,
+				5C1E9A6CE1C5CE2A2940D0C39384385B /* SEGStoreKitTracker.m */,
+				1B49E45FBA8888E6B080D272C4E2D82C /* SEGTrackPayload.h */,
+				12EFBD73F6A98774AB16D5F36AB1657F /* SEGTrackPayload.m */,
+				277128513D3F88935753AABDEF48C2E6 /* SEGUserDefaultsStorage.h */,
+				2846E10F9BF1609A4DA7F0E08EDFC2BF /* SEGUserDefaultsStorage.m */,
+				AF5B3D155B1DA4B3245F51DE14F6F237 /* SEGUtils.h */,
+				D9155026603089F4E514ADBBD5CDED30 /* SEGUtils.m */,
+				59083081EB17BF3B6FA18C3D0E644203 /* UIViewController+SEGScreen.h */,
+				91F2424E9BA318B7BE3666EBA199DB4E /* UIViewController+SEGScreen.m */,
+				E6C97E749ED195BBD4764F2DC055128E /* Support Files */,
 			);
-			name = "Amplitude-iOS";
-			path = "Amplitude-iOS";
-			sourceTree = "<group>";
-		};
-		A8A70390E6AF9213F8FE7E544E384405 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				159FC513EC45B6CCD52AEFFCB7DA85BD /* Expecta.xcconfig */,
-				D09826FF261A1E917BC82225E3F90C1B /* Expecta-dummy.m */,
-				F15FE16955131A608C7414E717E0CFA0 /* Expecta-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Expecta";
-			sourceTree = "<group>";
-		};
-		AC6BAB4F0DB51C2FD3B9C82D3978F40A /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				5B10F2102C350F346E1B322A2FF23DCD /* Specta.xcconfig */,
-				B352EF08411BAB450770E6E407CCEE55 /* Specta-dummy.m */,
-				4ED2CF514643512E05408DFF013A2BE6 /* Specta-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Specta";
+			name = Analytics;
+			path = Analytics;
 			sourceTree = "<group>";
 		};
 		AD84F200F442D573FFE30A8D9A27C9CC /* Pod */ = {
@@ -912,6 +907,17 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
+		CC1BD6FFC01DFAFCB0F066F6E36A999A /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				DC93F8AE31A351A4D7160035E38A8E66 /* Specta.xcconfig */,
+				B22B6EEAA9F357DCDCF57019CACE60FD /* Specta-dummy.m */,
+				66525BDE0651DE1CBEF16B921CDF1F6F /* Specta-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Specta";
+			sourceTree = "<group>";
+		};
 		CDF2F4D31E43B5CC30F85031ACFF6938 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -920,15 +926,26 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		D439994C6B4CDB6751C7E624E3FAB7D4 /* Resources */ = {
+		D3E8D6354B17D9469E1F953CF4C413E0 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				813CA4C07945BE63470A05648C78435E /* api.amplitude.com.der */,
-				C6A20B0188A3498C1BF941FFD2D6C1F4 /* ComodoCaLimitedRsaCertificationAuthority.der */,
-				E9CD8C83F50CA68BF5E95B196463D734 /* ComodoRsaCA.der */,
-				650C921B0925E66C82CC3E9F933C44B5 /* ComodoRsaDomainValidationCA.der */,
+				5512E39B0A265EC80350FF05010405A1 /* Amplitude-iOS */,
+				A91F3C2D0F1148D5F2E6DAB4F9115287 /* Analytics */,
+				1FE6F78864929E73E554CDEEA8D84322 /* Expecta */,
+				5A0627E3B6A6C999D8BD5F255E6B2A55 /* Specta */,
 			);
-			name = Resources;
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		E6C97E749ED195BBD4764F2DC055128E /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				3DF719B6D31E9F52D5329D17B4705148 /* Analytics.xcconfig */,
+				9F2D5B2C5AD2E82BABC5B945F8A376B9 /* Analytics-dummy.m */,
+				2B40FF86BB1EAC4DF28AE8D59884679B /* Analytics-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Analytics";
 			sourceTree = "<group>";
 		};
 		E988DCD4C308909B5CD4E120A27E7C8E /* Pods-Segment-Amplitude_Tests */ = {
@@ -944,17 +961,6 @@
 			);
 			name = "Pods-Segment-Amplitude_Tests";
 			path = "Target Support Files/Pods-Segment-Amplitude_Tests";
-			sourceTree = "<group>";
-		};
-		EC846CF90EB4A062FC620740030F48E3 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				A59A1D007D219A0F982965BDAB8BCBFA /* Amplitude-iOS */,
-				20A41EB11BD258ADB250E3C07FFF009B /* Analytics */,
-				27945C278F958A8CA533182161013E90 /* Expecta */,
-				4386EDA6C0B2B49527FD18FE6BD6A6F4 /* Specta */,
-			);
-			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1050,6 +1056,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AD804FBFA461987415A0DBB59D6C0F9A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				36E9E2403F3FA060379B647B429C22B7 /* AMPARCMacros.h in Headers */,
+				C3D1DB64E4A3EE65102EE6D9A6EFDBB4 /* AMPConstants.h in Headers */,
+				68B38793E0574CD875EDD8E1BC914262 /* AMPDatabaseHelper.h in Headers */,
+				E35A7B447A624DA509D11A8B98DAB789 /* AMPDeviceInfo.h in Headers */,
+				71C6345D00ED8D55C5EFD3390B00E839 /* AMPIdentify.h in Headers */,
+				21C03A3D7980F279C5E9E8D0FA3F7290 /* Amplitude+SSLPinning.h in Headers */,
+				2882F25D2EB1C0EF7F6D9DE330D2163F /* Amplitude.h in Headers */,
+				F27266EDE84CF2D787F8D12A2070DFCC /* AMPLocationManagerDelegate.h in Headers */,
+				1D0611791A479C096A261974E862430D /* AMPRevenue.h in Headers */,
+				99C1B92360E0411FB3567C7A7B5BD093 /* AMPURLConnection.h in Headers */,
+				DA94B03B875E2F5EB229839CE5AFEFFD /* AMPURLSession.h in Headers */,
+				F7BA61AFF6A8C44FD36F97FBE460EB12 /* AMPUtils.h in Headers */,
+				E1CCAA1A4C2AA15743720F3BB98CE1F6 /* ISPCertificatePinning.h in Headers */,
+				CAA9AE7CC0CFB7463ABA29294BE950B4 /* ISPPinnedNSURLConnectionDelegate.h in Headers */,
+				66A33667769C45DF871D2B58589642C2 /* ISPPinnedNSURLSessionDelegate.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D4D31CBFDD58211296159021EF1E79FB /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1072,37 +1100,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DE9E109EE4338DFF30C69BBB23CC67BD /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0EF8942E0E33E51B55984E21C7A20136 /* AMPARCMacros.h in Headers */,
-				F264F1D7C4574896B15D365188D746E9 /* AMPConstants.h in Headers */,
-				54F0E687B183C8E034CA170379539921 /* AMPDatabaseHelper.h in Headers */,
-				0DA1B8376BBADCBFDBCDC4629270D6B8 /* AMPDeviceInfo.h in Headers */,
-				3590C16CE4E209805008107AA030298F /* AMPIdentify.h in Headers */,
-				D0E39CD4D1D6437064DFA0ED3A52B804 /* Amplitude+SSLPinning.h in Headers */,
-				6EECEC0333224B25DDD5E9D0B582A43A /* Amplitude.h in Headers */,
-				0151A7ACCBD8575A076DB6E3B9C0556E /* AMPLocationManagerDelegate.h in Headers */,
-				E7187E94A151E266C65F3AC055E2EE3D /* AMPRevenue.h in Headers */,
-				899FEA8AB5E7DD13099D739016A7C8B0 /* AMPURLConnection.h in Headers */,
-				F1AEDCED73DFC82CAB1D12DA9DE1CDE0 /* AMPUtils.h in Headers */,
-				0876CA00867AB99301D67095C964DC14 /* ISPCertificatePinning.h in Headers */,
-				0EDCA96D2CBABE271438F3AF1480F559 /* ISPPinnedNSURLConnectionDelegate.h in Headers */,
-				DE50E4D62DF4F2445DC91B86E1E919DF /* ISPPinnedNSURLSessionDelegate.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		001F28535027D76314F16FA8B0CB7C29 /* Amplitude-iOS */ = {
+		1D45B8A36B1B88B0AEC790565370216C /* Amplitude-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E333249E69C5C2E2A212F952FEA32990 /* Build configuration list for PBXNativeTarget "Amplitude-iOS" */;
+			buildConfigurationList = FF84494C7328AF4C803C7EDAFA277D72 /* Build configuration list for PBXNativeTarget "Amplitude-iOS" */;
 			buildPhases = (
-				45C10C8329B7E9F98503C901ED542154 /* Sources */,
-				29F309B10465F223E9521685284E9F49 /* Frameworks */,
-				DE9E109EE4338DFF30C69BBB23CC67BD /* Headers */,
+				78DF2FED67446A4C45D6B179768389C1 /* Sources */,
+				445323DE568869B661B482F88F8F8CB3 /* Frameworks */,
+				AD804FBFA461987415A0DBB59D6C0F9A /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1241,7 +1248,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				001F28535027D76314F16FA8B0CB7C29 /* Amplitude-iOS */,
+				1D45B8A36B1B88B0AEC790565370216C /* Amplitude-iOS */,
 				F86D3609C2624C42E6812F06BE88209F /* Analytics */,
 				46D68D26DCAAC4D999D549BA45F0B0EC /* Expecta */,
 				B29E0A37935D1C99C08E9CF1EF252921 /* Pods-Segment-Amplitude_Example */,
@@ -1260,26 +1267,6 @@
 				6FBF87A9136D69B4A37F315E41A6629D /* SEGAmplitudeIntegration.m in Sources */,
 				0E46A173FDB21C2E617CD6C90EB00120 /* SEGAmplitudeIntegrationFactory.m in Sources */,
 				B64D916925D6355192B34ACBF0E3CAB0 /* Segment-Amplitude-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		45C10C8329B7E9F98503C901ED542154 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0D89BC56B4A2F94B5E837EA557CE3C97 /* AMPConstants.m in Sources */,
-				5D40C3F5EBFBB938CFA8D75FDD7A9A88 /* AMPDatabaseHelper.m in Sources */,
-				D5378B33D419C4831E260344216409B5 /* AMPDeviceInfo.m in Sources */,
-				12CAEA62439E19E8DC4A3CF341895A06 /* AMPIdentify.m in Sources */,
-				1117E7E92DEFCDC43417987EBCCD4C8F /* Amplitude-iOS-dummy.m in Sources */,
-				AB05672D2BBA27098774098132FDA347 /* Amplitude.m in Sources */,
-				57CDB8C458B23151680A72F8FF790C2A /* AMPLocationManagerDelegate.m in Sources */,
-				D2E41B1A5DAFEC9EB7FB1AED4CDA55D1 /* AMPRevenue.m in Sources */,
-				AF15E3217F4C0433B8E2D0EE2D7766F4 /* AMPURLConnection.m in Sources */,
-				84049BDA6FBD7B182C9F042ACAD324A0 /* AMPUtils.m in Sources */,
-				78C8DCB7421F061F52FAC2AACD10C031 /* ISPCertificatePinning.m in Sources */,
-				2E991C0BDB92169EF0708C841DCAFE46 /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
-				FFC03DEB31C2082586AFFD991367F6ED /* ISPPinnedNSURLSessionDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1340,6 +1327,27 @@
 				5D50DA13C7A8B2AF549AA4F05E69F9F4 /* EXPMatchers+respondTo.m in Sources */,
 				ED087996824EE3256B222E3BAEBAB14D /* EXPUnsupportedObject.m in Sources */,
 				4EB308BF802E6F21BABDA8B8718CC7AB /* NSValue+Expecta.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		78DF2FED67446A4C45D6B179768389C1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC92EB782AB4D2271AE246206166767A /* AMPConstants.m in Sources */,
+				B913D18ECB8DD2C03C34E01200123773 /* AMPDatabaseHelper.m in Sources */,
+				0652687B02287F1C8105F8DA90E27FD4 /* AMPDeviceInfo.m in Sources */,
+				FE05FC5E6C50456F3788649E50A5C289 /* AMPIdentify.m in Sources */,
+				2E97D89D5359566FBD438FC19E4744B0 /* Amplitude-iOS-dummy.m in Sources */,
+				4C81A557F494048C6BDED0223F280986 /* Amplitude.m in Sources */,
+				381147232BF488D76C6257F98C94D44F /* AMPLocationManagerDelegate.m in Sources */,
+				4AA93E82A0B82EFC88DFFE8542F68247 /* AMPRevenue.m in Sources */,
+				A22D5A3CDC023E295BCD8691C3652221 /* AMPURLConnection.m in Sources */,
+				6CFC9A323BC815AD85E9C18658A85C75 /* AMPURLSession.m in Sources */,
+				F7D80768CC80821E1FBE756AB9CC344C /* AMPUtils.m in Sources */,
+				3146D30BD7AB190A00B09B0888C2E8A2 /* ISPCertificatePinning.m in Sources */,
+				67E7E223BBB8307F3E9286B94E3498B8 /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
+				63BF505FE1B3A51426DAE5780BF6145E /* ISPPinnedNSURLSessionDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1420,7 +1428,7 @@
 		A0F8C38D9A584248979336F85979CC0E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Amplitude-iOS";
-			target = 001F28535027D76314F16FA8B0CB7C29 /* Amplitude-iOS */;
+			target = 1D45B8A36B1B88B0AEC790565370216C /* Amplitude-iOS */;
 			targetProxy = A1A4A7CA33FB7FD98143CCE12341E666 /* PBXContainerItemProxy */;
 		};
 		A2B53B80FBFAF2DE658DB8010F18E385 /* PBXTargetDependency */ = {
@@ -1432,7 +1440,7 @@
 		D91BE92882FAAA2F5AAC2448B642A5F9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Amplitude-iOS";
-			target = 001F28535027D76314F16FA8B0CB7C29 /* Amplitude-iOS */;
+			target = 1D45B8A36B1B88B0AEC790565370216C /* Amplitude-iOS */;
 			targetProxy = 6D0448FE98207670B855DECAA364E1F4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -1440,7 +1448,7 @@
 /* Begin XCBuildConfiguration section */
 		01C0630B664AA6C15A334D10714DA0A7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B22DF54B7066123934BD64EC79F0E751 /* Analytics.xcconfig */;
+			baseConfigurationReference = 3DF719B6D31E9F52D5329D17B4705148 /* Analytics.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1463,7 +1471,7 @@
 		};
 		0C62CC1C5F61F8DE8B5D801CE545676B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B22DF54B7066123934BD64EC79F0E751 /* Analytics.xcconfig */;
+			baseConfigurationReference = 3DF719B6D31E9F52D5329D17B4705148 /* Analytics.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1472,6 +1480,29 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		0E27219A317A34C91F2D25B71ED165AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3898DE5D367DF8E7F5799BD2C9E7A0B5 /* Amplitude-iOS.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Amplitude-iOS/Amplitude-iOS-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
@@ -1551,32 +1582,9 @@
 			};
 			name = Debug;
 		};
-		5764451069C3AAC12DC2F739C80A9D5B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 54E4323B155EE86D7930101B5D6D72CF /* Amplitude-iOS.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Amplitude-iOS/Amplitude-iOS-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
 		64F83F83876AD245C57752DDFCA45ED6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B10F2102C350F346E1B322A2FF23DCD /* Specta.xcconfig */;
+			baseConfigurationReference = DC93F8AE31A351A4D7160035E38A8E66 /* Specta.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1596,6 +1604,29 @@
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
+		};
+		7695E17DD7FEA90F111225D4273A78EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3898DE5D367DF8E7F5799BD2C9E7A0B5 /* Amplitude-iOS.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Amplitude-iOS/Amplitude-iOS-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
 		};
 		8550EA1D87928EB3226AA196A87B3E50 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1622,7 +1653,7 @@
 		};
 		8800C944B7DAF9074831889EA526E983 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 159FC513EC45B6CCD52AEFFCB7DA85BD /* Expecta.xcconfig */;
+			baseConfigurationReference = 4E6A73E02028A9E00279952D23CB9FED /* Expecta.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1645,7 +1676,7 @@
 		};
 		91AD35D4A147B0BBA893E3FAFE1A696B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B10F2102C350F346E1B322A2FF23DCD /* Specta.xcconfig */;
+			baseConfigurationReference = DC93F8AE31A351A4D7160035E38A8E66 /* Specta.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1712,32 +1743,9 @@
 			};
 			name = Release;
 		};
-		AC2A93675EBC4A20F448420850B5C5A3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 54E4323B155EE86D7930101B5D6D72CF /* Amplitude-iOS.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Amplitude-iOS/Amplitude-iOS-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
 		B16289E54EB6F80726D498769FC61609 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 159FC513EC45B6CCD52AEFFCB7DA85BD /* Expecta.xcconfig */;
+			baseConfigurationReference = 4E6A73E02028A9E00279952D23CB9FED /* Expecta.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1918,11 +1926,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E333249E69C5C2E2A212F952FEA32990 /* Build configuration list for PBXNativeTarget "Amplitude-iOS" */ = {
+		FF84494C7328AF4C803C7EDAFA277D72 /* Build configuration list for PBXNativeTarget "Amplitude-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5764451069C3AAC12DC2F739C80A9D5B /* Debug */,
-				AC2A93675EBC4A20F448420850B5C5A3 /* Release */,
+				7695E17DD7FEA90F111225D4273A78EE /* Debug */,
+				0E27219A317A34C91F2D25B71ED165AD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Segment-Amplitude.podspec
+++ b/Segment-Amplitude.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.6' # support for iOS 7 +
-  s.dependency 'Amplitude-iOS', '~> 3.14'
+  s.dependency 'Amplitude-iOS', '~> 4.0'
 end


### PR DESCRIPTION
Removes deprecated methods in preparation for iOS 11: https://github.com/amplitude/Amplitude-iOS/releases