### PR TITLE
Fix typo in Makefile so Travis actually tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ XCPRETTY := xcpretty -c && exit ${PIPESTATUS[0]}
 SDK ?= "iphonesimulator"
 DESTINATION ?= "platform=iOS Simulator,name=iPhone 5"
 PROJECT := Segment-Amplitude
-XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
+XC_ARGS := -scheme $(PROJECT)_Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 
 install: Example/Podfile $(PROJECT).podspec
 	pod repo update


### PR DESCRIPTION
Resolves

```
The command "make install" exited with 0.
$ make test
xcodebuild: error: The workspace named "Segment-Amplitude" does not contain a scheme named "Segment-Amplitude-Example". The "-list" option can be used to find the names of the schemes in the workspace.
```