### PR TITLE
Refactors revenue logic

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -154,7 +154,7 @@ describe(@"SEGAmplitudeIntegration", ^{
             [verify(amplitude) logEvent:@"Sent Product Link" withEventProperties:props withGroups:@{ @"jobs" : @[ @"Pendant Publishing" ] }];
         });
 
-        it(@"tracks Order Completed with revenue", ^{
+        it(@"tracks Order Completed with revenue if both total and revenue are present", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
@@ -181,6 +181,35 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             [integration track:payload];
             [[verify(amprevenue) setPrice:@8] setQuantity:1];
+            [verify(amplitude) logRevenueV2:amprevenue];
+        });
+
+        it(@"tracks Order Completed with total if revenue is not present", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
+                @"checkout_id" : @"9bcf000000000000",
+                @"order_id" : @"50314b8e",
+                @"affiliation" : @"App Store",
+                @"total" : @30.45,
+                @"shipping" : @5.05,
+                @"tax" : @1.20,
+                @"currency" : @"USD",
+                @"category" : @"Games",
+                @"products" : @{
+                    @"product_id" : @"2013294",
+                    @"category" : @"Games",
+                    @"name" : @"Monopoly: 3rd Edition",
+                    @"brand" : @"Hasbros",
+                    @"price" : @"21.99",
+                    @"quantity" : @"1"
+                }
+            }
+                context:@{}
+                integrations:@{}];
+
+            [integration track:payload];
+            [[verify(amprevenue) setPrice:@30.45] setQuantity:1];
             [verify(amplitude) logRevenueV2:amprevenue];
         });
 

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -19,33 +19,41 @@
 
         NSString *apiKey = [self.settings objectForKey:@"apiKey"];
         [self.amplitude initializeApiKey:apiKey];
+        SEGLog(@"[Amplitude initializeApiKey:%@]", apiKey);
 
         if ([(NSNumber *)[self.settings objectForKey:@"trackSessionEvents"] boolValue]) {
             self.amplitude.trackingSessionEvents = true;
+            SEGLog(@"[Amplitude.trackingSessionEvents = true]");
         }
     }
     return self;
 }
 
-+ (NSNumber *)extractRevenue:(NSDictionary *)dictionary withKey:(NSString *)revenueKey
++ (NSNumber *)extractRevenueOrTotal:(NSDictionary *)dictionary withRevenueKey:(NSString *)revenueKey andTotalKey:(NSString *)totalKey
 {
-    id revenueProperty = nil;
+    id revenueOrTotal = nil;
 
     for (NSString *key in dictionary.allKeys) {
+        // This may not be optimal, but we want to ensure that revenue is set if both total and revenue are present
         if ([key caseInsensitiveCompare:revenueKey] == NSOrderedSame) {
-            revenueProperty = dictionary[key];
+            revenueOrTotal = dictionary[key];
+            break;
+        }
+
+        if ([key caseInsensitiveCompare:totalKey] == NSOrderedSame) {
+            revenueOrTotal = dictionary[key];
             break;
         }
     }
 
-    if (revenueProperty) {
-        if ([revenueProperty isKindOfClass:[NSString class]]) {
+    if (revenueOrTotal) {
+        if ([revenueOrTotal isKindOfClass:[NSString class]]) {
             // Format the revenue.
             NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
             [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
-            return [formatter numberFromString:revenueProperty];
-        } else if ([revenueProperty isKindOfClass:[NSNumber class]]) {
-            return revenueProperty;
+            return [formatter numberFromString:revenueOrTotal];
+        } else if ([revenueOrTotal isKindOfClass:[NSNumber class]]) {
+            return revenueOrTotal;
         }
     }
     return nil;
@@ -54,12 +62,17 @@
 - (void)identify:(SEGIdentifyPayload *)payload
 {
     [self.amplitude setUserId:payload.userId];
+    SEGLog(@"[Amplitude setUserId:%@]", payload.userId);
     [self.amplitude setUserProperties:payload.traits];
+    SEGLog(@"[Amplitude setUserProperties:%@]", payload.traits);
+
     NSDictionary *options = payload.integrations[@"Amplitude"];
     NSDictionary *groups = [options isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
     if (groups && [groups isKindOfClass:[NSDictionary class]]) {
         [groups enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id _Nonnull obj, BOOL *_Nonnull stop) {
-            [self.amplitude setGroup:[NSString stringWithFormat:@"%@", key] groupName:obj];
+            NSString *formattedKey = [NSString stringWithFormat:@"%@", key];
+            [self.amplitude setGroup:formattedKey groupName:obj];
+            SEGLog(@"[Amplitude setGroup:%@ groupName:%@];", formattedKey, obj);
         }];
     }
 }
@@ -70,63 +83,67 @@
     NSDictionary *groups = [options isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
     if (groups && [groups isKindOfClass:[NSDictionary class]]) {
         [self.amplitude logEvent:event withEventProperties:properties withGroups:groups];
+        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ withGroups:%@];", event, properties, groups);
     } else {
         [self.amplitude logEvent:event withEventProperties:properties];
+        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@];", event, properties);
     }
 
     // Track revenue.
-    NSNumber *revenue = [SEGAmplitudeIntegration extractRevenue:properties withKey:@"revenue"];
-    if (revenue) {
-        // Use logRevenueV2 with revenue properties.
-        if ([(NSNumber *)[self.settings objectForKey:@"useLogRevenueV2"] boolValue]) {
-            id price = [properties objectForKey:@"price"];
-            id quantity = [properties objectForKey:@"quantity"];
+    [self trackRevenue:properties];
+}
 
-            // if no price fallback to using revenue
-            if (!price || ![price isKindOfClass:[NSNumber class]]) {
-                price = revenue;
-                quantity = [NSNumber numberWithInt:1];
-            } else if (!quantity || ![quantity isKindOfClass:[NSNumber class]]) {
-                quantity = [NSNumber numberWithInt:1];
-            }
+- (void)trackRevenue:(NSDictionary *)properties
+{
+    NSNumber *revenueOrTotal = [SEGAmplitudeIntegration extractRevenueOrTotal:properties withRevenueKey:@"revenue" andTotalKey:@"total"];
+    if (!revenueOrTotal) return;
 
-            [[self.amprevenue setPrice:price] setQuantity:[quantity integerValue]];
-            id productId = [properties objectForKey:@"productId"] ?: [properties objectForKey:@"product_id"];
-            if (productId && [productId isKindOfClass:[NSString class]] && ![productId isEqualToString:@""]) {
-                [self.amprevenue setProductIdentifier:productId];
-            }
+    id productId = [properties objectForKey:@"productId"] ?: [properties objectForKey:@"product_id"];
+    id quantity = [properties objectForKey:@"quantity"] ?: [NSNumber numberWithInt:1];
+    id receipt = [properties objectForKey:@"receipt"] ?: nil;
 
-            //Receipt is meant to be of type NSData
-            id receipt = [properties objectForKey:@"receipt"];
-            if (receipt && [receipt isKindOfClass:[NSString class]] && ![receipt isEqualToString:@""]) {
-                [self.amprevenue setReceipt:receipt];
-            }
-            id revenueType = [properties objectForKey:@"revenueType"] ?: [properties objectForKey:@"revenue_type"];
-            if (revenueType && [revenueType isKindOfClass:[NSString class]] && ![revenueType isEqualToString:@""]) {
-                [self.amprevenue setRevenueType:revenueType];
-            }
-            NSLog(@"Price : %@, Quantity : %@", price, quantity);
-            [self.amplitude logRevenueV2:self.amprevenue];
-        } else {
-            // fallback to logRevenue v1
-            id productId = [properties objectForKey:@"productId"] ?: [properties objectForKey:@"product_id"];
-            if (!productId || ![productId isKindOfClass:[NSString class]]) {
-                productId = nil;
-            }
-            id quantity = [properties objectForKey:@"quantity"];
-            if (!quantity || ![quantity isKindOfClass:[NSNumber class]]) {
-                quantity = [NSNumber numberWithInt:1];
-            }
-            id receipt = [properties objectForKey:@"receipt"];
-            if (!receipt || ![receipt isKindOfClass:[NSString class]]) {
-                receipt = nil;
-            }
-            NSLog(@"Number : %@", revenue);
-            [self.amplitude logRevenue:productId
-                              quantity:[quantity integerValue]
-                                 price:revenue
-                               receipt:receipt];
+    // Use logRevenueV2 with revenue properties.
+    if ([(NSNumber *)[self.settings objectForKey:@"useLogRevenueV2"] boolValue]) {
+        id price = [properties objectForKey:@"price"];
+
+        // if no price fallback to using revenue
+        if (!price || ![price isKindOfClass:[NSNumber class]]) {
+            price = revenueOrTotal;
         }
+
+        [[self.amprevenue setPrice:price] setQuantity:[quantity integerValue]];
+        SEGLog(@"[[AMPRevenue revenue] setPrice:%@] setQuantity: %d];", price, [quantity integerValue]);
+
+        if (productId && [productId isKindOfClass:[NSString class]] && ![productId isEqualToString:@""]) {
+            [self.amprevenue setProductIdentifier:productId];
+            SEGLog(@"[[AMPRevenue revenue] setProductIdentifier:%@];", productId);
+        }
+
+        // Amplitude expects receipt to be of type NSData. Previously, Segment checked for only type NSString. For backwards capability, removed the check
+        if (receipt) {
+            [self.amprevenue setReceipt:receipt];
+            SEGLog(@"[[AMPRevenue revenue] setReceipt:%@];", receipt);
+        }
+        id revenueType = [properties objectForKey:@"revenueType"] ?: [properties objectForKey:@"revenue_type"];
+        if (revenueType && [revenueType isKindOfClass:[NSString class]] && ![revenueType isEqualToString:@""]) {
+            [self.amprevenue setRevenueType:revenueType];
+            SEGLog(@"[AMPRevenue revenue] setRevenueType:%@];", revenueType);
+        }
+
+        [self.amplitude logRevenueV2:self.amprevenue];
+        SEGLog(@"[Amplitude logRevenueV2:%@];", self.amprevenue);
+
+    } else {
+        // fallback to logRevenue v1
+        if (!productId || ![productId isKindOfClass:[NSString class]]) {
+            productId = nil;
+        }
+
+        [self.amplitude logRevenue:productId
+                          quantity:[quantity integerValue]
+                             price:revenueOrTotal
+                           receipt:receipt];
+        SEGLog(@"[Amplitude logRevenue:%@ quantity:%d price:%@ receipt:%@];", productId, [quantity integerValue], revenueOrTotal, receipt);
     }
 }
 
@@ -148,18 +165,20 @@
     NSString *groupId = payload.groupId;
     if (groupId) {
         [self.amplitude setGroup:@"[Segment] Group" groupName:groupId];
+        SEGLog(@"[Amplitude setGroup:@'[Segment] Group' groupName:%@]", groupId);
     }
 }
 
 - (void)flush
 {
     [self.amplitude uploadEvents];
+    SEGLog(@"[Amplitude uploadEvents]");
 }
 
 - (void)reset
 {
     [self.amplitude regenerateDeviceId];
+    SEGLog(@"[Amplitude regnerateDeviceId];");
 }
-
 
 @end


### PR DESCRIPTION
- Fallsback on `total` if `revenue` is not present. 
- Rename `revenue` to `revenueOrTotal`
- Moved revenue logic into `trackRevenue` method. 
- Ensures `revenue` is mapped if both `revenue` and `total` are present
- Reduce redundant assignment of e-commerce reserved properties by assigning shared revenue properties outside the `logRevenueV2` check
- Amplitude expects `receipt` to be of type NSData. Previously, Segment checked for only type NSString. For backwards capability, removed type check when checking for `receipt` value
- Adds log statements