### PR TITLE
Use shorthand syntax, revert Makfile to pull in project podspec dynam…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DESTINATION ?= "platform=iOS Simulator,name=iPhone 5"
 PROJECT := Segment-Amplitude
 XC_ARGS := -scheme $(PROJECT)_Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 
-install: Example/Podfile Segment-Amplitude.podspec
+install: Example/Podfile $(PROJECT).podspec
 	pod repo update
 	pod install --project-directory=Example
 


### PR DESCRIPTION
- Use shorthand syntax
- Revert Makefile to pull in project podspec dynamically
- [Add comment](https://github.com/segment-integrations/analytics-ios-integration-amplitude/pull/39#discussion-diff-145830867L45) to missing break

Build succeeds with `xcodebuild -scheme Segment-Amplitude_Example -workspace Example/Segment-Amplitude.xcworkspace`

Tests succeeds with `xcodebuild test -scheme Segment-Amplitude_Example -workspace Example/Segment-Amplitude.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 5'`

`pod lib lint` succeeds