### PR TITLE
Fix trackAllPages string and supports other track page settings

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -89,8 +89,24 @@ describe(@"SEGAmplitudeIntegration", ^{
             [verifyCount(amplitude, never()) logEvent:@"Viewed Shirts Screen" withEventProperties:@{}];
         });
 
-        it(@"calls basic screen", ^{
+        it(@"calls trackAllPages screen", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackAllPages" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+
+            SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
+            [integration screen:payload];
+            [verify(amplitude) logEvent:@"Viewed Screen" withEventProperties:@{}];
+        });
+
+        it(@"calls trackCategorizedPages screen", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackCategorizedPages" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+
+            SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{ @"category" : @"Clothing" } context:@{} integrations:@{}];
+            [integration screen:payload];
+            [verify(amplitude) logEvent:@"Viewed Clothing Screen" withEventProperties:@{ @"category" : @"Clothing" }];
+        });
+
+        it(@"calls trackNamedPages screen", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackNamedPages" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
 
             SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
             [integration screen:payload];

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -152,6 +152,11 @@
 - (void)screen:(SEGScreenPayload *)payload
 {
     if ([(NSNumber *)self.settings[@"trackAllPages"] boolValue]) {
+        [self realTrack:@"Viewed Screen" properties:payload.properties integrations:payload.integrations];
+    } else if ([(NSNumber *)self.settings[@"trackCategorizedPages"] boolValue]) {
+        NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.properties[@"category"]];
+        [self realTrack:event properties:payload.properties integrations:payload.integrations];
+    } else if ([(NSNumber *)self.settings[@"trackNamedPages"] boolValue]) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
         [self realTrack:event properties:payload.properties integrations:payload.integrations];
     }


### PR DESCRIPTION
To bring this up to parity, `trackAllPages` is expected to send a `Loaded a Page` or `Viewed Screen` event as documented [here](https://segment.com/docs/destinations/amplitude/#track-all-pages-to-amplitude). 

The current `trackAllPages` behavior, creating a String from the Screen name is meant to be associated with the `trackNamedPages` setting. 

And finally, `trackCategorizedPages` is meant to create a Viewed Screen String with `properties.category`