### PR TITLE
Updates group to accept new group settings

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -107,8 +107,8 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"settings.groupTypeValue and settings.groupTypeTrait", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"groupTypeValue" : @"industry",
-                                                                               @"groupTypeTrait" : @"company" }
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"groupTypeValue" : @"company",
+                                                                               @"groupTypeTrait" : @"industry" }
                                                                andAmplitude:amplitude
                                                               andAmpRevenue:amprevenue];
             SEGGroupPayload *payload = [[SEGGroupPayload alloc] initWithGroupId:@"32423084" traits:@{
@@ -118,7 +118,7 @@ describe(@"SEGAmplitudeIntegration", ^{
                 context:@{}
                 integrations:@{}];
             [integration group:payload];
-            [verify(amplitude) setGroup:@"Technology" groupName:@"Segment"];
+            [verify(amplitude) setGroup:@"Segment" groupName:@"Technology"];
         });
 
         it(@"sets group name with traits.name", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -103,7 +103,28 @@ describe(@"SEGAmplitudeIntegration", ^{
         it(@"sets groupId", ^{
             SEGGroupPayload *payload = [[SEGGroupPayload alloc] initWithGroupId:@"322" traits:@{} context:@{} integrations:@{}];
             [integration group:payload];
-            [verify(amplitude) setGroup:@"[Segment] Group" groupName:@"322"];
+            [verify(amplitude) setGroup:@"322" groupName:@"[Segment] Group"];
+        });
+
+        it(@"settings.groupTypeValue and settings.groupTypeTrait", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"groupTypeValue" : @"industry",
+                                                                               @"groupTypeTrait" : @"company" }
+                                                               andAmplitude:amplitude
+                                                              andAmpRevenue:amprevenue];
+            SEGGroupPayload *payload = [[SEGGroupPayload alloc] initWithGroupId:@"32423084" traits:@{
+                @"company" : @"Segment",
+                @"industry" : @"Technology"
+            }
+                context:@{}
+                integrations:@{}];
+            [integration group:payload];
+            [verify(amplitude) setGroup:@"Technology" groupName:@"Segment"];
+        });
+
+        it(@"sets group name with traits.name", ^{
+            SEGGroupPayload *payload = [[SEGGroupPayload alloc] initWithGroupId:@"12342" traits:@{ @"name" : @"Segment" } context:@{} integrations:@{}];
+            [integration group:payload];
+            [verify(amplitude) setGroup:@"12342" groupName:@"Segment"];
         });
     });
 

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -159,22 +159,28 @@
 
 - (void)group:(SEGGroupPayload *)payload
 {
+    NSString *groupTypeTrait;
+    if (self.settings[@"groupTypeTrait"]) {
+        groupTypeTrait = self.settings[@"groupTypeTrait"];
+    }
+
+    NSString *groupTypeValue;
+    if (self.settings[@"groupTypeValue"]) {
+        groupTypeValue = self.settings[@"groupTypeValue"];
+    }
+
     NSString *groupName;
-    NSString *groupValue = payload.groupId;
-
-    NSString *groupTypeTrait = self.settings[@"groupTypeTrait"];
-    NSString *groupTypeValue = self.settings[@"groupTypeValue"];
-
+    NSString *groupValue;
     if ([payload.traits objectForKey:groupTypeTrait] && [payload.traits objectForKey:groupTypeValue]) {
         groupName = [payload.traits objectForKey:groupTypeTrait];
         groupValue = [payload.traits objectForKey:groupTypeValue];
-
     } else {
         groupName = payload.traits[@"name"] ?: @"[Segment] Group";
+        groupValue = payload.groupId;
     }
 
     [self.amplitude setGroup:groupValue groupName:groupName];
-    SEGLog(@"[Amplitude setGroup:%@' groupName:%@]", groupValue, groupName);
+    SEGLog(@"[Amplitude setGroup:%@ groupName:%@]", groupValue, groupName);
 }
 
 - (void)flush

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -159,21 +159,14 @@
 
 - (void)group:(SEGGroupPayload *)payload
 {
-    NSString *groupTypeTrait;
-    if (self.settings[@"groupTypeTrait"]) {
-        groupTypeTrait = self.settings[@"groupTypeTrait"];
-    }
-
-    NSString *groupTypeValue;
-    if (self.settings[@"groupTypeValue"]) {
-        groupTypeValue = self.settings[@"groupTypeValue"];
-    }
-
+    NSString *groupTypeTrait = self.settings[@"groupTypeTrait"];
+    NSString *groupTypeValue = self.settings[@"groupTypeValue"];
     NSString *groupName;
     NSString *groupValue;
+
     if (payload.traits[groupTypeTrait] && payload.traits[groupTypeValue]) {
-        groupName = [payload.traits objectForKey:groupTypeTrait];
-        groupValue = [payload.traits objectForKey:groupTypeValue];
+        groupName = payload.traits[groupTypeTrait];
+        groupValue = payload.traits[groupTypeValue];
     } else {
         groupName = payload.traits[@"name"] ?: @"[Segment] Group";
         groupValue = payload.groupId;

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -171,7 +171,7 @@
 
     NSString *groupName;
     NSString *groupValue;
-    if ([payload.traits objectForKey:groupTypeTrait] && [payload.traits objectForKey:groupTypeValue]) {
+    if (payload.traits[groupTypeTrait] && payload.traits[groupTypeValue]) {
         groupName = [payload.traits objectForKey:groupTypeTrait];
         groupValue = [payload.traits objectForKey:groupTypeValue];
     } else {

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -159,11 +159,22 @@
 
 - (void)group:(SEGGroupPayload *)payload
 {
-    NSString *groupId = payload.groupId;
-    if (groupId) {
-        [self.amplitude setGroup:@"[Segment] Group" groupName:groupId];
-        SEGLog(@"[Amplitude setGroup:@'[Segment] Group' groupName:%@]", groupId);
+    NSString *groupName;
+    NSString *groupValue = payload.groupId;
+
+    NSString *groupTypeTrait = self.settings[@"groupTypeTrait"];
+    NSString *groupTypeValue = self.settings[@"groupTypeValue"];
+
+    if ([payload.traits objectForKey:groupTypeTrait] && [payload.traits objectForKey:groupTypeValue]) {
+        groupName = [payload.traits objectForKey:groupTypeTrait];
+        groupValue = [payload.traits objectForKey:groupTypeValue];
+
+    } else {
+        groupName = payload.traits[@"name"] ?: @"[Segment] Group";
     }
+
+    [self.amplitude setGroup:groupValue groupName:groupName];
+    SEGLog(@"[Amplitude setGroup:%@' groupName:%@]", groupValue, groupName);
 }
 
 - (void)flush


### PR DESCRIPTION
Amplitude allows customers to send multiple types of groups on the same event, for example 
 `group_type`: org name 
`group_value`: engineering

`group_type`: org id 
`group_value`: 1234

The new Segment settings `groupTypeTrait` (group type) and `groupTypeValue` (group value) allow the user to set which keys the Segment integration will look for to determine what to set for group name and group values in Amplitude.

We will default to legacy behavior, which was incorrect prior to this PR (incorrectly setting group type as `[Segment] Group` and `group.id` to group name)