### PR TITLE
Sets userId to nil on reset

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -117,6 +117,7 @@ describe(@"SEGAmplitudeIntegration", ^{
     describe(@"Reset", ^{
         it(@"calls regenerateDeviceId", ^{
             [integration reset];
+            [verify(amplitude) setUserId:nil];
             [verify(amplitude) regenerateDeviceId];
         });
     });

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -174,6 +174,9 @@
 
 - (void)reset
 {
+    [self.amplitude setUserId:nil];
+    SEGLog(@"[Amplitude setUserId:nil");
+
     [self.amplitude regenerateDeviceId];
     SEGLog(@"[Amplitude regnerateDeviceId];");
 }


### PR DESCRIPTION
[According to Amplitude](https://amplitude.zendesk.com/hc/en-us/articles/115002278527#logging-out-and-anonymous-users), if a user logs out or you want to log the events under an anonymous user, you will need to:
1. Set the `userId` to `nil`.
2. Regenerate a new `deviceId`.