### PR TITLE
Adds functionality to increment traits if set

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -84,13 +84,15 @@ describe(@"SEGAmplitudeIntegration", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : @[ @"karma", @"store_credit" ] } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"3290842" anonymousId:nil traits:@{ @"karma" : @0.23,
-                                                                                                                          @"store_credit" : @20 }
+                                                                                                                          @"store_credit" : @20,
+                                                                                                                          @"gender" : @"female" }
                 context:@{}
                 integrations:@{}];
 
             [integration identify:payload];
             [verify(amplitude) identify:[identify add:@"karma" value:@0.23]];
             [verify(amplitude) identify:[identify add:@"store_credit" value:@20]];
+            [verify(amplitude) identify:[identify set:@"gender" value:@"female"]];
         });
 
     });
@@ -125,7 +127,8 @@ describe(@"SEGAmplitudeIntegration", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"groupTypeValue" : @"company",
                                                                                @"groupTypeTrait" : @"industry" }
                                                                andAmplitude:amplitude
-                                                              andAmpRevenue:amprevenue];
+                                                              andAmpRevenue:amprevenue
+                                                             andAmpIdentify:identify];
             SEGGroupPayload *payload = [[SEGGroupPayload alloc] initWithGroupId:@"32423084" traits:@{
                 @"company" : @"Segment",
                 @"industry" : @"Technology"

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -81,16 +81,16 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"increments identify trait", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : @[ @"karma", @"Store Credit" ] } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : @[ @"karma", @"store_credit" ] } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"3290842" anonymousId:nil traits:@{ @"karma" : @0.23,
-                                                                                                                          @"store credit" : @20 }
+                                                                                                                          @"store_credit" : @20 }
                 context:@{}
                 integrations:@{}];
 
             [integration identify:payload];
             [verify(amplitude) identify:[identify add:@"karma" value:@0.23]];
-            [verify(amplitude) identify:[identify add:@"store credit" value:@20]];
+            [verify(amplitude) identify:[identify add:@"store_credit" value:@20]];
         });
 
     });

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -35,11 +35,13 @@ describe(@"SEGAmplitudeIntegration", ^{
     __block Amplitude *amplitude;
     __block SEGAmplitudeIntegration *integration;
     __block AMPRevenue *amprevenue;
+    __block AMPIdentify *identify;
 
     beforeEach(^{
         amplitude = mock([Amplitude class]);
         amprevenue = mock([AMPRevenue class]);
-        integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{} andAmplitude:amplitude andAmpRevenue:amprevenue];
+        identify = mock([AMPIdentify class]);
+        integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{} andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
     });
 
     describe(@"Identify", ^{
@@ -78,11 +80,24 @@ describe(@"SEGAmplitudeIntegration", ^{
             [verify(amplitude) setGroup:@"jobs" groupName:@[ @"Pendant Publishing" ]];
         });
 
+        it(@"increments identify trait", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : @[ @"karma", @"Store Credit" ] } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+
+            SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"3290842" anonymousId:nil traits:@{ @"karma" : @0.23,
+                                                                                                                          @"store credit" : @20 }
+                context:@{}
+                integrations:@{}];
+
+            [integration identify:payload];
+            [verify(amplitude) identify:[identify add:@"karma" value:@0.23]];
+            [verify(amplitude) identify:[identify add:@"store credit" value:@20]];
+        });
+
     });
 
     describe(@"Screen", ^{
         it(@"does not call screen if trackAllPages = false", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackAllPages" : @false } andAmplitude:amplitude andAmpRevenue:amprevenue];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackAllPages" : @false } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
             [integration screen:payload];
@@ -90,7 +105,7 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"calls basic screen", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackAllPages" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackAllPages" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
             [integration screen:payload];
@@ -177,7 +192,7 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"tracks Order Completed with revenue if both total and revenue are present", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
                 @"checkout_id" : @"9bcf000000000000",
@@ -207,7 +222,7 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"tracks Order Completed with total if revenue is not present", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
                 @"checkout_id" : @"9bcf000000000000",
@@ -236,7 +251,7 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"tracks Order Completed with revenue of type String", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
                 @"checkout_id" : @"9bcf000000000000",
@@ -267,7 +282,7 @@ describe(@"SEGAmplitudeIntegration", ^{
 
         // NOTE: This is against our spec. We do not have a v1/v2 ECommerce event that sends both revenue and price/quantity as a tope level property
         it(@"tracks with top level price and quantity", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Viewed Product" properties:@{
                 @"revenue" : @20.99,
@@ -287,7 +302,7 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"tracks Amplitude ecommerce fields", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Viewed Product" properties:@{
                 @"revenue" : @20.00,

--- a/Pod/Classes/SEGAmplitudeIntegration.h
+++ b/Pod/Classes/SEGAmplitudeIntegration.h
@@ -13,8 +13,9 @@
 @property (nonatomic, strong) NSDictionary *settings;
 @property (strong) Amplitude *amplitude;
 @property (strong) AMPRevenue *amprevenue;
+@property AMPIdentify *identify;
 
 - (id)initWithSettings:(NSDictionary *)settings;
-- (id)initWithSettings:(NSDictionary *)settings andAmplitude:(Amplitude *)amplitude andAmpRevenue:(AMPRevenue *)amprevenue;
+- (id)initWithSettings:(NSDictionary *)settings andAmplitude:(Amplitude *)amplitude andAmpRevenue:(AMPRevenue *)amprevenue andAmpIdentify:(AMPIdentify *)identify;
 
 @end

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -70,10 +70,10 @@
         [payload.traits enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull key, id _Nonnull obj, BOOL *_Nonnull stop) {
             [self incrementTrait:key andValue:obj];
         }];
-    }
-
-    [self.amplitude setUserProperties:payload.traits];
-    SEGLog(@"[Amplitude setUserProperties:%@]", payload.traits);
+    } else {
+        [self.amplitude setUserProperties:payload.traits];
+        SEGLog(@"[Amplitude setUserProperties:%@]", payload.traits);
+    };
 
     NSDictionary *options = payload.integrations[@"Amplitude"];
     NSDictionary *groups = [options isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
@@ -204,11 +204,18 @@
 
 - (void)incrementTrait:(NSString *)trait andValue:(NSString *)value
 {
+    __block BOOL isAmountSet = false;
+
     NSArray *increments = self.settings[@"traitsToIncrement"];
     for (NSString *increment in increments) {
-        if ([trait isEqualToString:increment]) {
+        if ([increment isEqualToString:trait]) {
             [self.amplitude identify:[self.identify add:trait value:value]];
+            isAmountSet = @YES;
         }
+    }
+
+    if (!isAmountSet) {
+        [self.amplitude identify:[self.identify set:trait value:value]];
     }
 }
 

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -204,9 +204,9 @@
 
 - (void)incrementTrait:(NSString *)trait andValue:(NSString *)value
 {
-    NSArray *increments = [self.settings objectForKey:@"traitsToIncrement"];
+    NSArray *increments = self.settings[@"traitsToIncrement"];
     for (NSString *increment in increments) {
-        if ([trait caseInsensitiveCompare:increment] == NSOrderedSame) {
+        if ([trait isEqualToString:increment]) {
             [self.amplitude identify:[self.identify add:trait value:value]];
         }
     }


### PR DESCRIPTION
Supports Amplitude's `add` functionality. Will add a new setting `traitsToIncrement` to UI, which will accept an array of traits (of type NSString) to check in `identify.traits`. If the trait is present, it will increment the trait given the value passed in.  

This will increment a user property by some numerical value. If the user property does not have a value set yet, it will be initialized to 0 before being incremented.