### PR TITLE
Supports setOnce

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -47,7 +47,11 @@ describe(@"SEGAmplitudeIntegration", ^{
     describe(@"Identify", ^{
 
         it(@"identify without traits", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : [NSNull null] } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : [NSNull null],
+                                                                               @"traitsToSetOnce" : [NSNull null] }
+                                                               andAmplitude:amplitude
+                                                              andAmpRevenue:amprevenue
+                                                             andAmpIdentify:identify];
             SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"1111" anonymousId:nil traits:@{} context:@{} integrations:@{}];
 
             [integration identify:payload];
@@ -55,7 +59,11 @@ describe(@"SEGAmplitudeIntegration", ^{
         });
 
         it(@"identify with traits", ^{
-            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : @[] } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToIncrement" : @[],
+                                                                               @"traitsToSetOnce" : @[] }
+                                                               andAmplitude:amplitude
+                                                              andAmpRevenue:amprevenue
+                                                             andAmpIdentify:identify];
             SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"7891" anonymousId:nil traits:@{
                 @"name" : @"George Costanza",
                 @"gender" : @"male",
@@ -95,6 +103,46 @@ describe(@"SEGAmplitudeIntegration", ^{
             [verify(amplitude) identify:[identify add:@"karma" value:@0.23]];
             [verify(amplitude) identify:[identify add:@"store_credit" value:@20]];
             [verify(amplitude) identify:[identify set:@"gender" value:@"female"]];
+        });
+
+        it(@"sets identify trait once", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToSetOnce" : @[ @"sign_up_date" ] } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+
+            SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"3290842" anonymousId:nil traits:@{ @"sign_up_date" : @"2015-08-24",
+                                                                                                                          @"city" : @"los angeles" }
+                context:@{}
+                integrations:@{}];
+
+            [integration identify:payload];
+            [verify(amplitude) identify:[identify setOnce:@"sign_up_date" value:@"2015-08-24"]];
+            [verify(amplitude) identify:[identify set:@"city" value:@"los angeles"]];
+        });
+
+        it(@"sets identify trait once and increments trait", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"traitsToSetOnce" : @[ @"birthdate" ],
+                                                                               @"traitsToIncrement" : @[ @"age" ] }
+                                                               andAmplitude:amplitude
+                                                              andAmpRevenue:amprevenue
+                                                             andAmpIdentify:identify];
+
+            SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:@"3290842" anonymousId:nil traits:@{ @"address" : @{
+                @"street" : @"California st",
+                @"city" : @"San Francisco"
+            },
+                                                                                                                          @"birthdate" : @"1989-07-10",
+                                                                                                                          @"name" : @"ladan",
+                                                                                                                          @"age" : @28 }
+                context:@{}
+                integrations:@{}];
+
+            [integration identify:payload];
+            [verify(amplitude) identify:[identify setOnce:@"birthdate" value:@"1989-07-10"]];
+            [verify(amplitude) identify:[identify add:@"age" value:@28]];
+            [verify(amplitude) identify:[identify set:@"name" value:@"ladan"]];
+            [verify(amplitude) identify:[identify set:@"address" value:@{
+                @"street" : @"California st",
+                @"city" : @"San Francisco"
+            }]];
         });
 
     });

--- a/Pod/Classes/SEGAmplitudeIntegration.h
+++ b/Pod/Classes/SEGAmplitudeIntegration.h
@@ -15,6 +15,7 @@
 @property (strong) AMPRevenue *amprevenue;
 @property AMPIdentify *identify;
 @property NSSet *traitsToIncrement;
+@property NSSet *traitsToSetOnce;
 
 - (id)initWithSettings:(NSDictionary *)settings;
 - (id)initWithSettings:(NSDictionary *)settings andAmplitude:(Amplitude *)amplitude andAmpRevenue:(AMPRevenue *)amprevenue andAmpIdentify:(AMPIdentify *)identify;

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -21,6 +21,10 @@
             self.traitsToIncrement = [NSSet setWithArray:self.settings[@"traitsToIncrement"]];
         }
 
+        if (self.settings[@"traitsToSetOnce"] != (id)[NSNull null]) {
+            self.traitsToSetOnce = [NSSet setWithArray:self.settings[@"traitsToSetOnce"]];
+        }
+
         NSString *apiKey = self.settings[@"apiKey"];
         [self.amplitude initializeApiKey:apiKey];
         SEGLog(@"[Amplitude initializeApiKey:%@]", apiKey);
@@ -73,7 +77,7 @@
     [self.amplitude setUserId:payload.userId];
     SEGLog(@"[Amplitude setUserId:%@]", payload.userId);
 
-    if ([self.traitsToIncrement count] > 0) {
+    if ([self.traitsToIncrement count] > 0 || [self.traitsToSetOnce count] > 0) {
         [self incrementOrSetTraits:payload.traits];
     } else {
         [self.amplitude setUserProperties:payload.traits];
@@ -212,6 +216,8 @@
         if ([self.traitsToIncrement member:trait]) {
             [self.amplitude identify:[self.identify add:trait value:value]];
             SEGLog(@"[Amplitude add:%@ value:%@]", trait, value);
+        } else if ([self.traitsToSetOnce member:trait]) {
+            [self.amplitude identify:[self.identify setOnce:trait value:value]];
         } else {
             [self.amplitude identify:[self.identify set:trait value:value]];
             SEGLog(@"[Amplitude set:%@ value:%@]", trait, value);


### PR DESCRIPTION
`setOnce` sets the value of a user property only once. Subsequent `setOnce` operations on that user property will be ignored. 

Checks `traits` against values in `settings.traitsToSetOnce` 