### PR TITLE
Supports outOfSession via integration option &  logEvent

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -196,6 +196,37 @@ describe(@"SEGAmplitudeIntegration", ^{
             [verify(amplitude) logEvent:@"Sent Product Link" withEventProperties:props withGroups:@{ @"jobs" : @[ @"Pendant Publishing" ] }];
         });
 
+        it(@"doesn't track group if not NSDictionary", ^{
+            NSDictionary *props = @{
+                @"url" : @"seinfeld.wikia.com/wiki/The_Puffy_Shirt"
+            };
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Sent Product Link" properties:props context:@{} integrations:@{ @"Amplitude" : @{@"groups" : @"jobs"} }];
+            [integration track:payload];
+            [verify(amplitude) logEvent:@"Sent Product Link" withEventProperties:props];
+        });
+
+        it(@"tracks an event with groups and outOfSession", ^{
+            NSDictionary *props = @{
+                @"order_number" : @34294
+            };
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Delivered" properties:props context:@{} integrations:@{ @"Amplitude" : @{@"groups" : @{@"Buroughs" : @[ @"Brooklyn", @"Manhattan" ]}, @"outOfSession" : @YES} }];
+            [integration track:payload];
+            [verify(amplitude) logEvent:@"Order Delivered" withEventProperties:props withGroups:@{ @"Buroughs" : @[ @"Brooklyn", @"Manhattan" ] } outOfSession:true];
+        });
+
+        it(@"tracks an event with groups and outOfSession", ^{
+            NSDictionary *props = @{
+                @"reminder" : @"drink water"
+            };
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Reminder Sent" properties:props context:@{} integrations:@{ @"Amplitude" : @{@"outOfSession" : @YES} }];
+            [integration track:payload];
+            [verify(amplitude) logEvent:@"Reminder Sent" withEventProperties:props outOfSession:true];
+        });
+
+
         it(@"tracks Order Completed with revenue if both total and revenue are present", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -95,9 +95,17 @@
 {
     NSDictionary *options = integrations[@"Amplitude"];
     NSDictionary *groups = [options isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
-    if (groups && [groups isKindOfClass:[NSDictionary class]]) {
+    bool outOfSession = options[@"outOfSession"];
+
+    if (groups && [groups isKindOfClass:[NSDictionary class]] && outOfSession) {
+        [self.amplitude logEvent:event withEventProperties:properties withGroups:groups outOfSession:true];
+        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ withGroups:%@ outOfSession:true];", event, properties, groups);
+    } else if (groups && [groups isKindOfClass:[NSDictionary class]]) {
         [self.amplitude logEvent:event withEventProperties:properties withGroups:groups];
         SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ withGroups:%@];", event, properties, groups);
+    } else if (outOfSession) {
+        [self.amplitude logEvent:event withEventProperties:properties outOfSession:true];
+        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ outOfSession:true];", event, properties);
     } else {
         [self.amplitude logEvent:event withEventProperties:properties];
         SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@];", event, properties);

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -95,7 +95,7 @@
 {
     NSDictionary *options = integrations[@"Amplitude"];
     NSDictionary *groups = [options isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
-    bool outOfSession = options[@"outOfSession"];
+    bool outOfSession = [options isKindOfClass:[NSDictionary class]] ? options[@"outOfSession"] : false;
 
     if (groups && [groups isKindOfClass:[NSDictionary class]] && outOfSession) {
         [self.amplitude logEvent:event withEventProperties:properties withGroups:groups outOfSession:true];


### PR DESCRIPTION
Out-of-session events are not considered part of the current session, meaning they do not extend the current session. This might be useful if you are logging events triggered by push notifications, for example.

This supports calling `logEvent` with `outOfSession` passed in as true if the integration specific option is passed in: `integrations.amplitude.outOfSession`

There are four ways to log an event in Amplitude:
* Log event with props, groups and out of session flag
* Log event with props and groups
* Log event with props and out of session flag
* Log event with props