### PR TITLE
Checks integration option to force update location

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -234,6 +234,26 @@ describe(@"SEGAmplitudeIntegration", ^{
 
         });
 
+        it(@"tracks a basic event with updateLocation", ^{
+            NSDictionary *props = @{
+                @"Color" : @"White",
+                @"Type" : @"like the pirates used to wear"
+            };
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Viewed Puffy Shirt"
+                                                                   properties:props
+                                                                      context:@{}
+                                                                 integrations:@{
+                                                                     @"Amplitude" : @{
+                                                                         @"updateLocation" : @YES
+                                                                     }
+                                                                 }];
+
+            [integration track:payload];
+            [verify(amplitude) updateLocation];
+            [verify(amplitude) logEvent:@"Viewed Puffy Shirt" withEventProperties:props];
+
+        });
+
         it(@"tracks a basic event with groups", ^{
             NSDictionary *props = @{
                 @"url" : @"seinfeld.wikia.com/wiki/The_Puffy_Shirt"

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -97,8 +97,21 @@
 
 - (void)realTrack:(NSString *)event properties:(NSDictionary *)properties integrations:(NSDictionary *)integrations
 {
+    __block BOOL updateLocation = false;
+    __block NSDictionary *groups;
+
     NSDictionary *options = integrations[@"Amplitude"];
-    NSDictionary *groups = [options isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
+    if ([options isKindOfClass:[NSDictionary class]]) {
+        groups = options[@"groups"] ?: nil;
+        updateLocation = [options[@"updateLocation"] boolValue];
+    }
+
+
+    if (updateLocation) {
+        [self.amplitude updateLocation];
+        SEGLog(@"[[Amplitude instance] updateLocation]");
+    }
+
     if (groups && [groups isKindOfClass:[NSDictionary class]]) {
         [self.amplitude logEvent:event withEventProperties:properties withGroups:groups];
         SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ withGroups:%@];", event, properties, groups);


### PR DESCRIPTION
*iOS Only*

Gives option to  force Amplitude to grab the latest location by calling `[[Amplitude instance] updateLocation]` via Segment's integration option `updateLocation`

Amplitude warns that this does consume more resources on the user's device. Will be sure to document this warning.