### PR TITLE
Supports trackAllPagesV2 setting

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -156,12 +156,20 @@ describe(@"SEGAmplitudeIntegration", ^{
             [verifyCount(amplitude, never()) logEvent:@"Viewed Shirts Screen" withEventProperties:@{}];
         });
 
-        it(@"calls basic screen", ^{
+        it(@"trackAllPages", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackAllPages" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
             SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
             [integration screen:payload];
             [verify(amplitude) logEvent:@"Viewed Shirts Screen" withEventProperties:@{}];
+        });
+
+        it(@"trackAllPagesV2", ^{
+            integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"trackAllPagesV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+
+            SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
+            [integration screen:payload];
+            [verify(amplitude) logEvent:@"Loaded a Screen" withEventProperties:@{}];
         });
 
     });

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -169,7 +169,7 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
             [integration screen:payload];
-            [verify(amplitude) logEvent:@"Loaded a Screen" withEventProperties:@{}];
+            [verify(amplitude) logEvent:@"Loaded a Screen" withEventProperties:@{ @"name" : @"Shirts" }];
         });
 
     });

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -170,6 +170,13 @@
 
 - (void)screen:(SEGScreenPayload *)payload
 {
+    if ([(NSNumber *)[self.settings objectForKey:@"trackAllPagesV2"] boolValue]) {
+        NSString *event = [[NSString alloc] initWithFormat:@"Loaded a Screen"];
+        [self realTrack:event properties:payload.properties integrations:payload.integrations];
+        return;
+    }
+
+    // Deprecated.
     if ([(NSNumber *)self.settings[@"trackAllPages"] boolValue]) {
         NSString *event = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", payload.name];
         [self realTrack:event properties:payload.properties integrations:payload.integrations];

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -171,8 +171,9 @@
 - (void)screen:(SEGScreenPayload *)payload
 {
     if ([(NSNumber *)[self.settings objectForKey:@"trackAllPagesV2"] boolValue]) {
-        NSString *event = [[NSString alloc] initWithFormat:@"Loaded a Screen"];
-        [self realTrack:event properties:payload.properties integrations:payload.integrations];
+        NSMutableDictionary *payloadProps = [NSMutableDictionary dictionaryWithDictionary:payload.properties];
+        [payloadProps setValue:payload.name forKey:@"name"];
+        [self realTrack:@"Loaded a Screen" properties:payloadProps integrations:payload.integrations];
         return;
     }
 


### PR DESCRIPTION
The iOS component’s behavior was completely different than the Android/Server/Web components. Specifically,  the `trackAllPages` behaves like the `trackNamedPages` setting, and this component does not support the `trackNamedPages` and `trackCategorizedPages` settings 

This maintains the current `trackAllPages` behavior as is, then `trackAllPagesV2` will track the `Screen Viewed` as discussed. Since we decided to deprecate `trackNamedPages` and `trackCategorizedPages`, I did not merge #42 . 

If we decide not to deprecate the two settings, I can merge the above PR, which brings the iOS behavior to have parity with all the other components as is, then support `trackAllPagesV2` .