### PR TITLE
Sends extra props on ecommerce events

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -41,8 +41,7 @@ describe(@"SEGAmplitudeIntegration", ^{
         amplitude = mock([Amplitude class]);
         amprevenue = mock([AMPRevenue class]);
         identify = mock([AMPIdentify class]);
-        integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"apiKey" : @"76230f248487a2864cee36863d100c4d",
-        } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+        integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{} andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
     });
 
     describe(@"Identify", ^{
@@ -248,7 +247,7 @@ describe(@"SEGAmplitudeIntegration", ^{
         it(@"tracks Order Completed with revenue if both total and revenue are present", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
-            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
+            NSDictionary *props = @{
                 @"checkout_id" : @"9bcf000000000000",
                 @"order_id" : @"50314b8e",
                 @"affiliation" : @"App Store",
@@ -266,35 +265,21 @@ describe(@"SEGAmplitudeIntegration", ^{
                     @"price" : @"21.99",
                     @"quantity" : @"1"
                 }
-            } context:@{}
+            };
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:props context:@{}
                 integrations:@{}];
 
             [integration track:payload];
             [[verify(amprevenue) setPrice:@8] setQuantity:1];
-            [verify(amprevenue) setEventProperties:@{
-                @"checkout_id" : @"9bcf000000000000",
-                @"order_id" : @"50314b8e",
-                @"affiliation" : @"App Store",
-                @"shipping" : @5.05,
-                @"tax" : @1.20,
-                @"currency" : @"USD",
-                @"category" : @"Games",
-                @"products" : @{
-                    @"product_id" : @"2013294",
-                    @"category" : @"Games",
-                    @"name" : @"Monopoly: 3rd Edition",
-                    @"brand" : @"Hasbros",
-                    @"price" : @"21.99",
-                    @"quantity" : @"1"
-                }
-            }];
+            [verify(amprevenue) setEventProperties:props];
             [verify(amplitude) logRevenueV2:amprevenue];
         });
 
         it(@"tracks Order Completed with total if revenue is not present", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
-            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
+            NSDictionary *props = @{
                 @"checkout_id" : @"9bcf000000000000",
                 @"order_id" : @"50314b8e",
                 @"affiliation" : @"App Store",
@@ -311,36 +296,22 @@ describe(@"SEGAmplitudeIntegration", ^{
                     @"price" : @"21.99",
                     @"quantity" : @"1"
                 }
-            }
+            };
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:props
                 context:@{}
                 integrations:@{}];
 
             [integration track:payload];
             [[verify(amprevenue) setPrice:@30.45] setQuantity:1];
-            [verify(amprevenue) setEventProperties:@{
-                @"checkout_id" : @"9bcf000000000000",
-                @"order_id" : @"50314b8e",
-                @"affiliation" : @"App Store",
-                @"shipping" : @5.05,
-                @"tax" : @1.20,
-                @"currency" : @"USD",
-                @"category" : @"Games",
-                @"products" : @{
-                    @"product_id" : @"2013294",
-                    @"category" : @"Games",
-                    @"name" : @"Monopoly: 3rd Edition",
-                    @"brand" : @"Hasbros",
-                    @"price" : @"21.99",
-                    @"quantity" : @"1"
-                }
-            }];
+            [verify(amprevenue) setEventProperties:props];
             [verify(amplitude) logRevenueV2:amprevenue];
         });
 
         it(@"tracks Order Completed with revenue of type String", ^{
             integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"useLogRevenueV2" : @true } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
 
-            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:@{
+            NSDictionary *props = @{
                 @"checkout_id" : @"9bcf000000000000",
                 @"order_id" : @"50314b8e",
                 @"affiliation" : @"App Store",
@@ -358,29 +329,14 @@ describe(@"SEGAmplitudeIntegration", ^{
                     @"price" : @"21.99",
                     @"quantity" : @"1"
                 }
-            }
-                context:@{}
+            };
+
+            SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Order Completed" properties:props context:@{}
                 integrations:@{}];
 
             [integration track:payload];
             [[verify(amprevenue) setPrice:@8] setQuantity:1];
-            [verify(amprevenue) setEventProperties:@{
-                @"checkout_id" : @"9bcf000000000000",
-                @"order_id" : @"50314b8e",
-                @"affiliation" : @"App Store",
-                @"shipping" : @5.05,
-                @"tax" : @1.20,
-                @"currency" : @"USD",
-                @"category" : @"Games",
-                @"products" : @{
-                    @"product_id" : @"2013294",
-                    @"category" : @"Games",
-                    @"name" : @"Monopoly: 3rd Edition",
-                    @"brand" : @"Hasbros",
-                    @"price" : @"21.99",
-                    @"quantity" : @"1"
-                }
-            }];
+            [verify(amprevenue) setEventProperties:props];
             [verify(amplitude) logRevenueV2:amprevenue];
         });
 

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -41,7 +41,8 @@ describe(@"SEGAmplitudeIntegration", ^{
         amplitude = mock([Amplitude class]);
         amprevenue = mock([AMPRevenue class]);
         identify = mock([AMPIdentify class]);
-        integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{} andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
+        integration = [[SEGAmplitudeIntegration alloc] initWithSettings:@{ @"apiKey" : @"76230f248487a2864cee36863d100c4d",
+        } andAmplitude:amplitude andAmpRevenue:amprevenue andAmpIdentify:identify];
     });
 
     describe(@"Identify", ^{
@@ -265,12 +266,28 @@ describe(@"SEGAmplitudeIntegration", ^{
                     @"price" : @"21.99",
                     @"quantity" : @"1"
                 }
-            }
-                context:@{}
+            } context:@{}
                 integrations:@{}];
 
             [integration track:payload];
             [[verify(amprevenue) setPrice:@8] setQuantity:1];
+            [verify(amprevenue) setEventProperties:@{
+                @"checkout_id" : @"9bcf000000000000",
+                @"order_id" : @"50314b8e",
+                @"affiliation" : @"App Store",
+                @"shipping" : @5.05,
+                @"tax" : @1.20,
+                @"currency" : @"USD",
+                @"category" : @"Games",
+                @"products" : @{
+                    @"product_id" : @"2013294",
+                    @"category" : @"Games",
+                    @"name" : @"Monopoly: 3rd Edition",
+                    @"brand" : @"Hasbros",
+                    @"price" : @"21.99",
+                    @"quantity" : @"1"
+                }
+            }];
             [verify(amplitude) logRevenueV2:amprevenue];
         });
 
@@ -300,6 +317,23 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             [integration track:payload];
             [[verify(amprevenue) setPrice:@30.45] setQuantity:1];
+            [verify(amprevenue) setEventProperties:@{
+                @"checkout_id" : @"9bcf000000000000",
+                @"order_id" : @"50314b8e",
+                @"affiliation" : @"App Store",
+                @"shipping" : @5.05,
+                @"tax" : @1.20,
+                @"currency" : @"USD",
+                @"category" : @"Games",
+                @"products" : @{
+                    @"product_id" : @"2013294",
+                    @"category" : @"Games",
+                    @"name" : @"Monopoly: 3rd Edition",
+                    @"brand" : @"Hasbros",
+                    @"price" : @"21.99",
+                    @"quantity" : @"1"
+                }
+            }];
             [verify(amplitude) logRevenueV2:amprevenue];
         });
 
@@ -330,6 +364,23 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             [integration track:payload];
             [[verify(amprevenue) setPrice:@8] setQuantity:1];
+            [verify(amprevenue) setEventProperties:@{
+                @"checkout_id" : @"9bcf000000000000",
+                @"order_id" : @"50314b8e",
+                @"affiliation" : @"App Store",
+                @"shipping" : @5.05,
+                @"tax" : @1.20,
+                @"currency" : @"USD",
+                @"category" : @"Games",
+                @"products" : @{
+                    @"product_id" : @"2013294",
+                    @"category" : @"Games",
+                    @"name" : @"Monopoly: 3rd Edition",
+                    @"brand" : @"Hasbros",
+                    @"price" : @"21.99",
+                    @"quantity" : @"1"
+                }
+            }];
             [verify(amplitude) logRevenueV2:amprevenue];
         });
 

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -135,14 +135,23 @@
 
 - (void)trackLogRevenueV2:(NSDictionary *)properties andRevenueOrTotal:(NSNumber *)revenueOrTotal
 {
+    NSMutableDictionary *revenueProps = [[NSMutableDictionary alloc] initWithDictionary:properties];
+
     NSNumber *price = properties[@"price"] ?: revenueOrTotal;
+    [revenueProps removeObjectForKey:@"price"];
+    [revenueProps removeObjectForKey:@"revenue"];
+    [revenueProps removeObjectForKey:@"total"];
+
     NSNumber *quantity = properties[@"quantity"] ?: [NSNumber numberWithInt:1];
+    [revenueProps removeObjectForKey:quantity];
+
     [[self.amprevenue setPrice:price] setQuantity:[quantity integerValue]];
     SEGLog(@"[[AMPRevenue revenue] setPrice:%@] setQuantity: %d];", price, [quantity integerValue]);
 
     NSString *productId = properties[@"productId"] ?: properties[@"product_id"];
     if (productId && ![productId isEqualToString:@""]) {
         [self.amprevenue setProductIdentifier:productId];
+        [revenueProps removeObjectForKey:productId];
         SEGLog(@"[[AMPRevenue revenue] setProductIdentifier:%@];", productId);
     }
 
@@ -150,13 +159,20 @@
     id receipt = properties[@"receipt"];
     if (receipt) {
         [self.amprevenue setReceipt:receipt];
+        [revenueProps removeObjectForKey:receipt];
         SEGLog(@"[[AMPRevenue revenue] setReceipt:%@];", receipt);
     }
 
     NSString *revenueType = properties[@"revenueType"] ?: properties[@"revenue_type"];
     if (revenueType && ![revenueType isEqualToString:@""]) {
         [self.amprevenue setRevenueType:revenueType];
+        [revenueProps removeObjectForKey:revenueType];
         SEGLog(@"[AMPRevenue revenue] setRevenueType:%@];", revenueType);
+    }
+
+    if ([revenueProps count] > 0) {
+        [self.amprevenue setEventProperties:revenueProps];
+        SEGLog(@"[AMPRevenue revenue] setEventProperties:%@];", revenueProps);
     }
 
     [self.amplitude logRevenueV2:self.amprevenue];

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -135,23 +135,14 @@
 
 - (void)trackLogRevenueV2:(NSDictionary *)properties andRevenueOrTotal:(NSNumber *)revenueOrTotal
 {
-    NSMutableDictionary *revenueProps = [[NSMutableDictionary alloc] initWithDictionary:properties];
-
     NSNumber *price = properties[@"price"] ?: revenueOrTotal;
-    [revenueProps removeObjectForKey:@"price"];
-    [revenueProps removeObjectForKey:@"revenue"];
-    [revenueProps removeObjectForKey:@"total"];
-
     NSNumber *quantity = properties[@"quantity"] ?: [NSNumber numberWithInt:1];
-    [revenueProps removeObjectForKey:quantity];
-
     [[self.amprevenue setPrice:price] setQuantity:[quantity integerValue]];
     SEGLog(@"[[AMPRevenue revenue] setPrice:%@] setQuantity: %d];", price, [quantity integerValue]);
 
     NSString *productId = properties[@"productId"] ?: properties[@"product_id"];
     if (productId && ![productId isEqualToString:@""]) {
         [self.amprevenue setProductIdentifier:productId];
-        [revenueProps removeObjectForKey:productId];
         SEGLog(@"[[AMPRevenue revenue] setProductIdentifier:%@];", productId);
     }
 
@@ -159,21 +150,17 @@
     id receipt = properties[@"receipt"];
     if (receipt) {
         [self.amprevenue setReceipt:receipt];
-        [revenueProps removeObjectForKey:receipt];
         SEGLog(@"[[AMPRevenue revenue] setReceipt:%@];", receipt);
     }
 
     NSString *revenueType = properties[@"revenueType"] ?: properties[@"revenue_type"];
     if (revenueType && ![revenueType isEqualToString:@""]) {
         [self.amprevenue setRevenueType:revenueType];
-        [revenueProps removeObjectForKey:revenueType];
         SEGLog(@"[AMPRevenue revenue] setRevenueType:%@];", revenueType);
     }
 
-    if ([revenueProps count] > 0) {
-        [self.amprevenue setEventProperties:revenueProps];
-        SEGLog(@"[AMPRevenue revenue] setEventProperties:%@];", revenueProps);
-    }
+    [self.amprevenue setEventProperties:properties];
+    SEGLog(@"[AMPRevenue revenue] setEventProperties:%@];", properties);
 
     [self.amplitude logRevenueV2:self.amprevenue];
     SEGLog(@"[Amplitude logRevenueV2:%@];", self.amprevenue);


### PR DESCRIPTION
The AmpRevenue object accepts any miscellaneous properties. This will send all properties to Amplitude ecommerce events.

We don't remove the duplicate properties since the Android component does not remove the reserved properties, and you can build funnels off of the properties. Removing them and bringing Android to parity would cause a breaking change. 
