### PR TITLE
Cleans up logEvent logic and integration option variables in track

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -161,7 +161,7 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"Shirts" properties:@{} context:@{} integrations:@{}];
             [integration screen:payload];
-            [verify(amplitude) logEvent:@"Viewed Shirts Screen" withEventProperties:@{}];
+            [verify(amplitude) logEvent:@"Viewed Shirts Screen" withEventProperties:@{} withGroups:nil outOfSession:false];
         });
 
         it(@"trackAllPagesV2", ^{
@@ -174,7 +174,7 @@ describe(@"SEGAmplitudeIntegration", ^{
             [integration screen:payload];
             [verify(amplitude) logEvent:@"Loaded a Screen" withEventProperties:@{ @"name" : @"Shirts",
                                                                                   @"url" : @"seinfeld.wikia.com/wiki/The_Puffy_Shirt",
-                                                                                  @"Feed Type" : @"private" }];
+                                                                                  @"Feed Type" : @"private" } withGroups:nil outOfSession:false];
         });
 
     });
@@ -229,7 +229,7 @@ describe(@"SEGAmplitudeIntegration", ^{
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Email Sent" properties:@{} context:@{} integrations:@{}];
 
             [integration track:payload];
-            [verify(amplitude) logEvent:@"Email Sent" withEventProperties:@{}];
+            [verify(amplitude) logEvent:@"Email Sent" withEventProperties:@{} withGroups:nil outOfSession:false];
         });
 
         it(@"tracks a basic event with props", ^{
@@ -243,7 +243,7 @@ describe(@"SEGAmplitudeIntegration", ^{
                 integrations:@{}];
 
             [integration track:payload];
-            [verify(amplitude) logEvent:@"Viewed Puffy Shirt" withEventProperties:props];
+            [verify(amplitude) logEvent:@"Viewed Puffy Shirt" withEventProperties:props withGroups:nil outOfSession:false];
 
         });
 
@@ -254,7 +254,7 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Sent Product Link" properties:props context:@{} integrations:@{ @"Amplitude" : @{@"groups" : @{@"jobs" : @[ @"Pendant Publishing" ]}} }];
             [integration track:payload];
-            [verify(amplitude) logEvent:@"Sent Product Link" withEventProperties:props withGroups:@{ @"jobs" : @[ @"Pendant Publishing" ] }];
+            [verify(amplitude) logEvent:@"Sent Product Link" withEventProperties:props withGroups:@{ @"jobs" : @[ @"Pendant Publishing" ] } outOfSession:false];
         });
 
         it(@"doesn't track group if not NSDictionary", ^{
@@ -264,7 +264,7 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Sent Product Link" properties:props context:@{} integrations:@{ @"Amplitude" : @{@"groups" : @"jobs"} }];
             [integration track:payload];
-            [verify(amplitude) logEvent:@"Sent Product Link" withEventProperties:props];
+            [verify(amplitude) logEvent:@"Sent Product Link" withEventProperties:props withGroups:nil outOfSession:false];
         });
 
         it(@"tracks an event with groups and outOfSession", ^{
@@ -284,7 +284,7 @@ describe(@"SEGAmplitudeIntegration", ^{
 
             SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Reminder Sent" properties:props context:@{} integrations:@{ @"Amplitude" : @{@"outOfSession" : @YES} }];
             [integration track:payload];
-            [verify(amplitude) logEvent:@"Reminder Sent" withEventProperties:props outOfSession:true];
+            [verify(amplitude) logEvent:@"Reminder Sent" withEventProperties:props withGroups:nil outOfSession:true];
         });
 
 

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -107,23 +107,17 @@
 
 - (void)realTrack:(NSString *)event properties:(NSDictionary *)properties integrations:(NSDictionary *)integrations
 {
-    NSDictionary *options = integrations[@"Amplitude"];
-    NSDictionary *groups = [options isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
-    bool outOfSession = [options isKindOfClass:[NSDictionary class]] ? options[@"outOfSession"] : false;
+    __block NSDictionary *groups;
+    __block bool outOfSession = false;
 
-    if (groups && [groups isKindOfClass:[NSDictionary class]] && outOfSession) {
-        [self.amplitude logEvent:event withEventProperties:properties withGroups:groups outOfSession:true];
-        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ withGroups:%@ outOfSession:true];", event, properties, groups);
-    } else if (groups && [groups isKindOfClass:[NSDictionary class]]) {
-        [self.amplitude logEvent:event withEventProperties:properties withGroups:groups];
-        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ withGroups:%@];", event, properties, groups);
-    } else if (outOfSession) {
-        [self.amplitude logEvent:event withEventProperties:properties outOfSession:true];
-        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ outOfSession:true];", event, properties);
-    } else {
-        [self.amplitude logEvent:event withEventProperties:properties];
-        SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@];", event, properties);
+    NSDictionary *options = integrations[@"Amplitude"];
+    if ([options isKindOfClass:[NSDictionary class]]) {
+        groups = [options[@"groups"] isKindOfClass:[NSDictionary class]] ? options[@"groups"] : nil;
+        outOfSession = [options[@"outOfSession"] boolValue];
     }
+
+    [self.amplitude logEvent:event withEventProperties:properties withGroups:groups outOfSession:outOfSession];
+    SEGLog(@"[Amplitude logEvent:%@ withEventProperties:%@ withGroups:%@ outOfSession:true];", event, properties, groups);
 
     // Track revenue. If revenue is not present fallback on total
     NSNumber *revenueOrTotal = [SEGAmplitudeIntegration extractRevenueOrTotal:properties withRevenueKey:@"revenue" andTotalKey:@"total"];


### PR DESCRIPTION
Per feedback in #52 , cleans up branched logic for `logEvent`. Amplitude does in fact call `logEvent` with the additional arguments as `nil` for each method. 

This simplifies assigning the `groups` and `outOfSession` arguments, and passing either `nil` or `false` if they are not set.

![screenshot 2017-10-30 11 30 51](https://user-images.githubusercontent.com/7421111/32188710-cc08d53a-bd65-11e7-888f-a43626c583dc.png)
