### PR TITLE
Update Amplitude ios sdk version

### DIFF
--- a/Segment-Amplitude.podspec
+++ b/Segment-Amplitude.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.6' # support for iOS 7 +
-  s.dependency 'Amplitude-iOS', '~> 4.0'
+  s.dependency 'Amplitude-iOS', '~> 4.8'
 end


### PR DESCRIPTION
From the [changelog](https://github.com/amplitude/Amplitude-iOS/edit/master/CHANGELOG.md):


## 4.8.1 (September 19, 2019)

* Suppress NSLogs for non-dev environments.

## 4.8.0 (September 3, 2019)

* Identify Macs for Mac Catalyst support.

## 4.7.1 (August 20, 2019)

* Fix issue where tag wasn't included in tag spec

## 4.7.0 (August 20, 2019)

* Fix bug where background task might be stopped before final events are flushed
* Revert logic to restore db from memory on potential db resets

## 4.6.0 (March 1, 2019)

* Add support for installing on tvOS platform via Carthage
* Do not use IDFV or IDFA for device ID if disabled via tracking options
* Close Sqlite DB object even if open fails
* Made `startOrContinueSession` public method. Only call this if you know what you are doing. This may trigger a new session to start.
* Properly end background event flush task
* Increased minimum iOS deployment target to 8.0


## 4.5.0 (December 18, 2018)

* Add ability to set a custom server URL for uploading events using `setServerUrl`.

## 4.4.0 (October 15, 2018)

* Add ability to set group properties via a new `groupIdentifyWithGroupType` method that takes in an `AMPIdentify` object as well as a group type and group name.

## 4.3.1 (August 14, 2018)

* Update SDK to better handle SQLite Exceptions.

## 4.3.0 (July 24, 2018)

* Add `AMPTrackingOptions` interface to customize the automatic tracking of user properties in the SDK (such as language, ip_address, platform, etc). See [Help Center Documentation](https://amplitude.zendesk.com/hc/en-us/articles/115002278527#disable-automatic-tracking-of-properties) for instructions on setting up this configuration.

## 4.2.1 (May 21, 2018)

* Fix a bunch of compiler warnings
* Fix SSLPinning import so that it doesn't corrupt debug console. Thanks to @rob-keepsafe for the PR

## 4.2.0 (April 19, 2018)

* Added a `setUserId` method with optional boolean argument `startNewSession`, which when `YES` starts a new session after changing the userId.

## 4.1.0 (February 27, 2018)
* Add option to disable IDFA tracking. To disable IDFA tracking call `[[Amplitude instance] disableIdfaTracking];` before initializing with your API key.