### PR TITLE
Specify the version Amplitude to depend on

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "amplitude/Amplitude-iOS"
+github "amplitude/Amplitude-iOS" ~> 5.2.1
 github "segmentio/analytics-ios"

--- a/Segment-Amplitude.podspec
+++ b/Segment-Amplitude.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics'
-  s.dependency 'Amplitude'
+  s.dependency 'Amplitude', '~> 5.2.1'
 end


### PR DESCRIPTION
Current merge is supposed to resolve the problem of non-building the project after making 

`pod update/carthage update`

due to major update of 'Amplitude'. 

Thank you in advance for reviewing,

Regards