### PR TITLE
Fix issue while reading values from SEGGroupPayload in group() call

### DIFF
--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -212,7 +212,7 @@
 - (void)group:(SEGGroupPayload *)payload
 {
     NSString *groupTypeTrait = self.settings[@"groupTypeTrait"];
-    NSString *groupTypeValue = self.settings[@"groupTypeValue"];
+    NSString *groupTypeValue = self.settings[@"groupValueTrait"];
     NSString *groupName = payload.traits[groupTypeTrait];
     NSString *groupValue = payload.traits[groupTypeValue];
 

--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -221,7 +221,7 @@
         groupValue = payload.groupId;
     }
 
-    [self.amplitude setGroup:groupValue groupName:groupName];
+    [self.amplitude setGroup:groupName groupName:groupValue];
     SEGLog(@"[Amplitude setGroup:%@ groupName:%@]", groupValue, groupName);
 }
 


### PR DESCRIPTION
Amplitude group call with `group_type` and `group_value` traits wasn't working without this fix.