### PR TITLE
Reinitialize identify when Reset is called

### DIFF
--- a/Pod/Classes/SEGAmplitudeIntegration.m
+++ b/Pod/Classes/SEGAmplitudeIntegration.m
@@ -241,6 +241,9 @@
 
     [self.amplitude regenerateDeviceId];
     SEGLog(@"[Amplitude regnerateDeviceId];");
+    
+    self.identify = [AMPIdentify identify];
+    SEGLog(@"[Amplitude reset identify];");
 }
 
 #pragma utils


### PR DESCRIPTION
When reset is called, reinitialize identify otherwise old traits will continue through new identify calls.