### PR TITLE
Sync SPM dependency versions with Cocoapods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
 		.library(name: "Segment_Amplitude", targets: ["Segment_Amplitude"]),
 	],
 	dependencies: [
-		.package(name: "Amplitude", url: "https://github.com/amplitude/Amplitude-iOS", .upToNextMinor(from: "8.3.1")),
-		.package(name: "Segment", url: "https://github.com/segmentio/analytics-ios", .upToNextMinor(from: "4.1.4"))
+		.package(name: "Amplitude", url: "https://github.com/amplitude/Amplitude-iOS", .upToNextMajor(from: "8.3.1")),
+		.package(name: "Segment", url: "https://github.com/segmentio/analytics-ios", .upToNextMajor(from: "4.1.4"))
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
I've noticed this issue when migrating all my project's libs from Cocoapods to SPM.

Dependency version rules are not in sync between [Podspec](https://github.com/segment-integrations/analytics-ios-integration-amplitude/blob/107a08433e65fc52030a2eb683cadbdd51df4eef/Segment-Amplitude.podspec#L28-L29) & [Package](https://github.com/segment-integrations/analytics-ios-integration-amplitude/blob/107a08433e65fc52030a2eb683cadbdd51df4eef/Package.swift#L16-L17) files.

When using `Segment_Amplitude` through SPM, we can't get the latest versions of its own dependencies, which we could when installing `Segment_Amplitude ` through Cocoapods.